### PR TITLE
promisify - converts node callbacks to promises

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -205,3 +205,25 @@ Promise.prototype = {
 };
 
 EventTarget.mixin(Promise.prototype);
+
+var slice = Array.prototype.slice;
+exports.promisify = function(func) {
+  return function() {
+    var promise = new Promise(),
+        args = slice.call(arguments, 0);
+    args.push(function(err) {
+      if (err) {
+        promise.reject(err);
+      } else {
+        if (arguments.length === 2) {
+          promise.resolve(arguments[1]);
+        } else {
+          promise.resolve(slice.call(arguments, 1));
+        }
+      }
+    });
+    func.apply(null, args);
+    return promise;
+  };
+};
+

--- a/tests/promisify.js
+++ b/tests/promisify.js
@@ -1,0 +1,29 @@
+rsvp = require('../lib/rsvp');
+
+function equal(actual, expected, desc) {
+  if (actual === expected) {
+    console.log('passed:', desc);
+  } else {
+    console.log('***failed***:', 'expected', expected, 'to equal', actual);
+  }
+}
+
+testfunc = function(a, b, callback) {
+  setTimeout(function(){
+    callback(null, a, b);
+  }, 1);
+};
+
+testfunc(1, 2, function(a, b, c){
+  equal(a, null, 'called with first param');
+  equal(b, 1, 'called with second param');
+  equal(c, 2, 'called with third param');
+});
+
+ptest = rsvp.promisify(testfunc);
+
+ptest(1, 2).then(function(values) {
+  equal(values[0], 1, 'called with first param');
+  equal(values[1], 2, 'called with second param');
+});
+


### PR DESCRIPTION
Just starting a conversation here, I was talking to Yehuda about this tonight on freenode.

Pretty simple, you can turn the usual node callback pattern into promises like so:

``` javascript
var fs = require('fs');
var RSVP = require('rsvp');

// create a new function that'll return a promise
var readFile = RSVP.promisify(fs.readFile);

// usage
readFile('sample.txt').then(function(data) {
  console.log(data.toString());
});
```

I didn't know where to put tests in this repository since it just runs the Promises/A specs. Before its merged it would need some test coverage and a better commit message, but anyway ...

Asking for your thoughts on the validity of adding this to rsvp and if this is the right API?
