### PR TITLE
EventTarget: set handler for multiple events at once

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -78,34 +78,40 @@ var EventTarget = exports.EventTarget = {
     return object;
   },
 
-  on: function(eventName, callback, binding) {
-    var allCallbacks = callbacksFor(this), callbacks;
+  on: function(eventNames, callback, binding) {
+    var allCallbacks = callbacksFor(this), callbacks, eventName;
+    eventNames = eventNames.split(/\s+/);
     binding = binding || this;
 
-    callbacks = allCallbacks[eventName];
+    while (eventName = eventNames.shift()) {
+      callbacks = allCallbacks[eventName];
 
-    if (!callbacks) {
-      callbacks = allCallbacks[eventName] = [];
-    }
+      if (!callbacks) {
+        callbacks = allCallbacks[eventName] = [];
+      }
 
-    if (indexOf(callbacks, callback) === -1) {
-      callbacks.push([callback, binding]);
+      if (indexOf(callbacks, callback) === -1) {
+        callbacks.push([callback, binding]);
+      }
     }
   },
 
-  off: function(eventName, callback) {
-    var allCallbacks = callbacksFor(this), callbacks;
+  off: function(eventNames, callback) {
+    var allCallbacks = callbacksFor(this), callbacks, eventName, index;
+    eventNames = eventNames.split(/\s+/);
 
-    if (!callback) {
-      allCallbacks[eventName] = [];
-      return;
+    while (eventName = eventNames.shift()) {
+      if (!callback) {
+        allCallbacks[eventName] = [];
+        continue;
+      }
+
+      callbacks = allCallbacks[eventName];
+
+      index = indexOf(callbacks, callback);
+
+      if (index !== -1) { callbacks.splice(index, 1); }
     }
-
-    callbacks = allCallbacks[eventName];
-
-    var index = indexOf(callbacks, callback);
-
-    if (index !== -1) { callbacks.splice(index, 1); }
   },
 
   trigger: function(eventName, options) {


### PR DESCRIPTION
This is a simple change to EventTarget that allows you to bind & unbind a handler function to multiple events at once. Event names are separated with a space:

``` javascript
function Foo() {};
RSVP.EventTarget.mixin(Foo.prototype);

var foo = new Foo();

foo.on("bar baz", function(event) {
  console.log("something happened!");
});

foo.trigger("foo");
foo.trigger("bar");

foo.off("foo bar");
```

This passes the existing test suite. If you're interested in merging this, I'd be happy to add tests & documentation for the additional functionality but I need some guidance as to how you plan on adding tests to this project.
