### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,12 @@ Here is an example of a simple XHR2 wrapper written using RSVP.js:
 var getJSON = function(url) {
   var promise = new RSVP.Promise();
 
-  var client = new XMLHTTPRequest();
+  var client = new XMLHttpRequest();
   client.open("GET", url);
   client.onreadystatechange = handler;
   client.responseType = "json";
   client.setRequestHeader("Accept", "application/json");
+  client.send();
 
   function handler() {
     if (this.readyState === this.DONE) {


### PR DESCRIPTION
In the example XHR2 wrapper,
1.) `XMLHTTPRequest` should be `XMLHttpRequest`
2.) `client` is missing a `send()` call, maybe after `setRequestHeader`. Trying to execute the code does nothing!
