### PR TITLE
Fix '[Promises/A] Attaching handlers later' test

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -179,6 +179,16 @@ Promise.prototype = {
   then: function(done, fail) {
     var thenPromise = new Promise();
 
+    if (this.isResolved) {
+      exports.async(function() {
+        invokeCallback('resolve', thenPromise, done, {detail: this.isResolved });
+      }, this);
+    } else if (this.isRejected) {
+      exports.async(function() {
+        invokeCallback('reject', thenPromise, fail, {detail: this.isRejected });
+      }, this);
+    }
+
     this.on('promise:resolved', function(event) {
       invokeCallback('resolve', thenPromise, done, event);
     });


### PR DESCRIPTION
This is a small addition to check whether the promise has already been fulfilled when `then` is called.

This fixes the '[Promises/A] Attaching handlers later' test that was recently added in https://github.com/domenic/promise-tests/commit/c70198347040b7e8d5d998f58c147e39f56eee45 .

---

With the addition of the fulfillment callback tests (https://github.com/domenic/promise-tests/issues/8), rsvp.js no longer passes the promises tests on https://github.com/domenic/promise-tests.

---

Note: Remember to clean/remove the browser folder and run `rake` before running the browser tests.
