### PR TITLE
broken `npm install rsvp` fixes #44

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,6 @@
 /.npmignore
 /.bundle
 /component.json
-/index.js
 /bin
 /browser/
 /node_modules/

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('lib/rsvp');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rsvp",
   "version": "1.2.0",
   "description": "A lightweight library that provides tools for organizing asynchronous code",
-  "main": "lib/rsvp.js",
+  "main": "node/rsvp.js",
   "directories": { "lib": "lib" },
   "devDependencies": {
     "jshint": "~0.9",


### PR DESCRIPTION
- Pointed to `node/rsvp.js` in `package.json` since `lib` is ignored in `.npmignore`
- Removed `index.js` completely since both `component.json` and `package.json` point to `node/rsvp.js`
