### PR TITLE
Reject promise if resolver function throws an exception

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -41,7 +41,11 @@ var Promise = function(resolver) {
     this.trigger('error', { detail: event.detail });
   }, this);
 
-  resolver(resolvePromise, rejectPromise);
+  try {
+    resolver(resolvePromise, rejectPromise);
+  } catch(e) {
+    rejectPromise(e);
+  }
 };
 
 var invokeCallback = function(type, promise, callback, event) {

--- a/tests/extension-tests.js
+++ b/tests/extension-tests.js
@@ -81,6 +81,15 @@ describe("RSVP extensions", function() {
       }, TypeError);
     });
 
+    it('should reject on resolver exception', function(done) {
+      var promise = RSVP.Promise(function() {
+        throw 'error';
+      }).then(null, function(e) {
+        assert.equal(e, 'error');
+        done();
+      });
+    });
+
     describe('assimilation', function() {
       it('should assimilate if `resolve` is called with a fulfilled promise', function(done) {
         var originalPromise = new RSVP.Promise(function(resolve) { resolve('original value'); });


### PR DESCRIPTION
``` javascript
var promise = new Promise(function() {
  throw 'error';
});

promise.then(null, function(reason) {
  // rejection callback is called
  reason === 'error'; // true
});
```
