### PR TITLE
Minor clarification in README on routes re: propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Errors also propagate:
 getJSON("/posts.json").then(function(posts) {
 
 }).then(null, function(error) {
-  // even though no error callback was passed to the
-  // first `.then`, the error propagates
+  // since no rejection handler was passed to the
+  // first `.then`, the error propagates.
 });
 ```
 


### PR DESCRIPTION
The original explanation's 'even though' is misleading, giving you the impression that if the first `.then` included an error handler, the second `.then`'s error handler would have fired, which only the case if the first error handler threw an error or returned RSVP.reject.

Perhaps we'll want another paragraph explaining how to "rethrow" a reject, but for now this should do.
