### PR TITLE
Make `RSVP.denodeify` pass along `thisArg`.

### DIFF
--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -16,6 +16,7 @@ function makeNodeCallbackFor(resolve, reject) {
 function denodeify(nodeFunc) {
   return function()  {
     var nodeArgs = Array.prototype.slice.call(arguments), resolve, reject;
+    var thisArg = this;
 
     var promise = new Promise(function(nodeResolve, nodeReject) {
       resolve = nodeResolve;
@@ -26,7 +27,7 @@ function denodeify(nodeFunc) {
       nodeArgs.push(makeNodeCallbackFor(resolve, reject));
 
       try {
-        nodeFunc.apply(this, nodeArgs);
+        nodeFunc.apply(thisArg, nodeArgs);
       } catch(e) {
         reject(e);
       }

--- a/tests/extension-tests.js
+++ b/tests/extension-tests.js
@@ -273,6 +273,23 @@ describe("RSVP extensions", function() {
       });
     });
 
+    specify('calls node function with same thisArg', function(done) {
+      var thisArg = null;
+
+      function nodeFunc(cb) {
+        thisArg = this;
+        cb();
+      }
+
+      var denodeifiedFunc = RSVP.denodeify(nodeFunc);
+      var expectedThis = { expect: "me" };
+
+      denodeifiedFunc.call(expectedThis).then(function() {
+        assert.equal(thisArg, expectedThis);
+        done();
+      });
+    });
+
     specify('waits for promise/thenable arguments to settle before passing them to the node function', function(done) {
       var args = null;
 


### PR DESCRIPTION
See discussion in #55.

I couldn't get the Ruby stuff working ("No such file or directory - which compile-modules" when following directions from #67) so make sure the tests pass before merging.
