### PR TITLE
Throw exception in all called without an array

### DIFF
--- a/lib/rsvp/all.js
+++ b/lib/rsvp/all.js
@@ -1,6 +1,9 @@
 import { Promise } from "rsvp/promise";
 
 function all(promises) {
+  if(toString.call(promises) !== "[object Array]") {
+    throw new TypeError('You must pass an array to all.');
+  }
   return new Promise(function(resolve, reject) {
     var results = [], remaining = promises.length,
     promise;

--- a/tests/extension-tests.js
+++ b/tests/extension-tests.js
@@ -483,6 +483,20 @@ describe("RSVP extensions", function() {
       assert(RSVP.all);
     });
 
+    it('throws when not passed an array', function() {
+      assert.throws(function () {
+        var all = RSVP.all();
+      }, TypeError);
+
+      assert.throws(function () {
+        var all = RSVP.all('');
+      }, TypeError);
+
+      assert.throws(function () {
+        var all = RSVP.all({});
+      }, TypeError);
+    });
+
     specify('fulfilled only after all of the other promises are fulfilled', function(done) {
       var firstResolved, secondResolved, firstResolver, secondResolver;
 


### PR DESCRIPTION
Avoid unresolvable `all` due to wrong input type. See #82
