### PR TITLE
Variant of the 'then' method that takes a hash of params

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -105,6 +105,10 @@ Promise.prototype = {
     });
 
     return thenPromise;
+  },
+
+  andThen: function(opts) {
+    return this.then(opts.done, opts.fail);
   }
 };
 


### PR DESCRIPTION
I'm not sure how you feel about CoffeeScript, but this was a small enough and useful-enough-to-me addition that I thought I'd share it in case you'd like to incorporate it.

I also wasn't sure where a good place to stick a test would be for this.

Adds a version of 'then' called 'andThen' that takes a hash of done / fail
functions instead of those functions as separate parameters.

The motivation is to make rsvp.js somewhat more friendly in CoffeeScript,
where multiple function arguments and chaining can require parentheses that
are usually able to be left out.

With 'then' the required CoffeeScript is:

``` coffeescript
myPromise.then(
  (res) -> (
    res = res + 1
    res / 2
  ),
  (error) -> (raise 'I failed')
).then(
  (res) -> (res + 2),
  (error) -> (console.log 'more errors')
)
```

Whereas 'andThen' allows the more ideomatic:

``` coffeescript
myPromise.andThen
  done: (res) ->
    res = res + 1
    res / 2
  fail: (error) -> raise 'I failed'
.andThen
  done: (res) -> res + 2
  fail: (error) -> console.log 'more errors'
```

where indentation tells the whole story and parentheses to offset the function
bodies and parameter lists are unneeded.
