### PR TITLE
[WIP] Implement done()

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -61,12 +61,17 @@ var invokeCallback = function(type, promise, callback, event) {
       value, error, succeeded, failed;
 
   if (hasCallback) {
-    try {
+    if(promise._done) {
       value = callback(event.detail);
       succeeded = true;
-    } catch(e) {
-      failed = true;
-      error = e;
+    } else {
+      try {
+        value = callback(event.detail);
+        succeeded = true;
+      } catch(e) {
+        failed = true;
+        error = e;
+      }
     }
   } else {
     value = event.detail;
@@ -115,6 +120,11 @@ Promise.prototype = {
     });
 
     return thenPromise;
+  },
+
+  done: function() {
+    this._done = true;
+    return this;
   }
 };
 

--- a/test/tests/extension_test.js
+++ b/test/tests/extension_test.js
@@ -622,6 +622,67 @@ describe("RSVP extensions", function() {
     });
   });
 
+  function catchExceptions(test, errorHandler) {
+    if(typeof module !== 'undefined' && module.exports) {
+      var Domain = require('domain');
+      var domain = Domain.create();
+
+      domain.on('error', errorHandler);
+
+      domain.run(test);
+    } else {
+      var previousOnError = window.onerror;
+
+      window.onerror = function(error) {
+        errorHandler(error);
+        window.onerror = previousOnError;
+        return false;
+      };
+
+      test();
+    }
+  }
+
+
+  describe("done()", function() {
+    specify('it prevents catching erorrs in failure callback', function(done) {
+      catchExceptions(function() {
+        new RSVP.Promise(function(resolve, reject) {
+          reject();
+        }).then(null, function() {
+          throw "foobar";
+        }).done();
+      }, function(error) {
+        assert.equal("foobar", error, "The thrown error was not caught");
+        done();
+      });
+    });
+
+    specify('it prevents catching erorrs in success callback', function(done) {
+      catchExceptions(function() {
+        new RSVP.Promise(function(resolve) {
+          resolve();
+        }).then(function() {
+          throw "foobar";
+        }).done();
+      }, function(error) {
+        assert.equal("foobar", error, "The thrown error was not caught");
+        done();
+      });
+    });
+
+    specify('it allows to still run success callbacks if they succeed', function(done) {
+      new RSVP.Promise(function(resolve, reject) {
+        resolve();
+      }).then(function() {
+        assert(true, 'It ran the first resolve callback');
+      }).done().then(function() {
+        assert(true, 'It ran the first resolve callback');
+        done();
+      });
+    });
+  });
+
   describe("RSVP.onerror", function(){
     var onerror;
 


### PR DESCRIPTION
I've started work on `done()` implementation, which would tell the promise that the chain is stopped. It will be useful in places where you want to stop catching errors in callbacks, especially in libraries. For example right now we can do something like this:

``` javascript
functionReturningApromise().then(userSuccessCallback, userFailureCallback).
  then(null, function(error) {
    console.log('there was an error while processing your callbacks:', error);
  });
```

This is not optimal, because you loose the stack trace and you can't easily set debugger to break on unhandled exception to check what's going on. Instead you would need to set debugger to stop on any exception, which is harder to do - typically there are at least a few exceptions thrown around.

What would be better is:

``` javascript
functionReturningApromise().then(userSuccessCallback, userFailureCallback).done();
```

In such case if there is any error in `userSuccessCallback` or in `userFailureCallback`, the exception will be thrown and user will immediately see the problem.

The implementation here is just a start, I'm pretty sure that it's not complete, but I would like to get a feedback on this feature proposal and also ask about sane way to write tests for it. I've implemented a simple `catchExceptions` function, which will catch exceptions in asynchronous code, but it fails in the browser part without much info on what's going on. Is there any better way to do this?

I will appreciate any feedback.
