### PR TITLE
fix test load order issue

### DIFF
--- a/options/browserify.js
+++ b/options/browserify.js
@@ -1,8 +1,8 @@
 module.exports = {
   tests: {
     src: ['test/test-adapter.js',
-          'node_modules/promises-aplus-tests/lib/tests/**/*.js',
-          'node_modules/promises-aplus-tests/node_modules/sinon/lib/{sinon.js,sinon/*.js}'],
+          'node_modules/promises-aplus-tests/node_modules/sinon/lib/{sinon.js,sinon/*.js}',
+          'node_modules/promises-aplus-tests/lib/tests/**/*.js'],
     dest: 'tmp/tests-bundle.js'
   }
 };


### PR DESCRIPTION
I am actually quite confused by this one, as the file declaration order did not change during the refactoring.
