### PR TITLE
async: use three args for addEventListener

### DIFF
--- a/lib/rsvp/async.js
+++ b/lib/rsvp/async.js
@@ -41,7 +41,7 @@ function useMutationObserver() {
   window.addEventListener('unload', function(){
     observer.disconnect();
     observer = null;
-  });
+  }, false);
 
   return function(callback, arg) {
     queue.push([callback, arg]);


### PR DESCRIPTION
The third argument for `addEventListener` and `removeEventListener` is supposed to be optional, defaulting to `false`, but some browsers (notably older versions of FireFox) require it.

See https://github.com/thinkpixellab/PxLoader/issues/5 and https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.removeEventListener
