### PR TITLE
Add allSettled to RSVP

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -2,6 +2,7 @@ import Promise from "./rsvp/promise";
 import EventTarget from "./rsvp/events";
 import denodeify from "./rsvp/node";
 import all from "./rsvp/all";
+import allSettled from "./rsvp/all_settled";
 import race from "./rsvp/race";
 import hash from "./rsvp/hash";
 import rethrow from "./rsvp/rethrow";
@@ -38,4 +39,4 @@ if (typeof window !== 'undefined' && typeof window.__PROMISE_INSTRUMENTATION__ =
   }
 }
 
-export { Promise, EventTarget, all, race, hash, rethrow, defer, denodeify, configure, on, off, resolve, reject, async, map, filter };
+export { Promise, EventTarget, all, allSettled, race, hash, rethrow, defer, denodeify, configure, on, off, resolve, reject, async, map, filter };

--- a/lib/rsvp/all_settled.js
+++ b/lib/rsvp/all_settled.js
@@ -1,0 +1,106 @@
+import Promise from "./promise";
+import { isArray, isNonThenable } from "./utils";
+
+/**
+  `RSVP.allSettled` is similar to `RSVP.all`, but instead of implementing
+  a fail-fast method, it waits until all the promises have returned and
+  shows you all the results. This is useful if you want to handle multiple
+  promises' failure states together as a set.
+
+  Returns a promise that is fulfilled when all the given promises have been
+  settled. The return promise is fulfilled with an array of the states of
+  the promises passed into the `promises` array argument.
+
+  Each state object will either indicate fulfillment or rejection, and
+  provide the corresponding value or reason. The states will take one of
+  the following formats:
+
+  ```javascript
+  { state: "fulfilled", value: value }
+    or
+  { state: "rejected", reason: reason }
+  ```
+
+  Example:
+
+  ```javascript
+  var promise1 = RSVP.resolve(1);
+  var promise2 = RSVP.reject(new Error("2"));
+  var promise3 = RSVP.reject(new Error("3"));
+  var promises = [ promise1, promise2, promise3 ];
+
+  RSVP.allSettled(promises).then(function(array){
+    // array == [
+    //   { state: "fulfilled", value: 1 },
+    //   { state: "rejected", reason: Error },
+    //   { state: "rejected", reason: Error }
+    // ]
+    // Note that for the second item, reason.message will be "2", and for the
+    // third item, reason.message will be "3".
+  }, function(error) {
+    // Not run. (This block would only be called if allSettled had failed,
+    // for instance if passed an incorrect argument type.)
+  });
+  ```
+
+  @method @allSettled
+  @for RSVP
+  @param {Array} promises;
+  @param {String} label - optional string that describes the promise.
+  Useful for tooling.
+  @return {Promise} promise that is fulfilled with an array of the settled
+  states of the constituent promises.
+*/
+
+export default function allSettled(entries, label) {
+  return new Promise(function(resolve, reject) {
+    if (!isArray(entries)) {
+      throw new TypeError('You must pass an array to allSettled.');
+    }
+
+    var remaining = entries.length;
+    var results = new Array(remaining);
+    var entry;
+
+    if (remaining === 0) {
+      resolve([]);
+    }
+
+    function fulfilledState(value) {
+      return { state: "fulfilled", value: value };
+    }
+
+    function rejectedState(reason) {
+      return { state: "rejected", reason: reason };
+    }
+
+    function fulfilledResolver(index) {
+      return function(value) {
+        resolveAll(index, fulfilledState(value) );
+      };
+    }
+
+    function rejectedResolver(index) {
+      return function(reason) {
+        resolveAll(index, rejectedState(reason) );
+      };
+    }
+
+    function resolveAll(index, value) {
+      results[index] = value;
+      if (--remaining === 0) {
+        resolve(results);
+      }
+    }
+
+    for (var index = 0; index < entries.length; index++) {
+      entry = entries[index];
+
+      if (isNonThenable(entry)) {
+        resolveAll(index, fulfilledState(entry) );
+      } else {
+        Promise.cast(entry).then( fulfilledResolver(index), rejectedResolver(index) );
+      }
+    }
+  }, label);
+};


### PR DESCRIPTION
The existing `RSVP.all` method implements essentially a fail-fast method of resolving an array of promises. But sometimes you don't want the fail-fast behavior and instead want to be able to inspect the final states of a bunch of promises, whether they succeed or fail. One use case I've encountered is in doing validation handling when saving a bunch of related records in Ember — if you want to be able to trigger client-side logic based on the responses to _all_ the record states, `RSVP.all` is not really effective, because it doesn't continue after the first one.

So this PR would add another method `RSVP.allSettled` that transforms an array of promises into a promise for an array of their states. These states will take one of the following formats:

```
{ state: 'fulfilled', value: value }
  or
{ state: 'rejected', reason: reason }
```

These result states are taken from [a similar allSettled function in the Q library](https://github.com/kriskowal/q/blob/master/q.js#L1585) (compare also the [allSettled tests](https://github.com/kriskowal/q/blob/master/spec/q-spec.js#L1175)). And for coherence with the existing RSVP codebase, I've kept the implementation, function and variable names, etc, as close as possible to `RSVP.all` for the time being.

I've never sent a GitHub PR before, so I'd obviously be grateful for any tips or suggestions!
