### PR TITLE
Performance improvements via simplifying and optimizing event emitter

### DIFF
--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -1,26 +1,13 @@
-var Event = function(type, options) {
-  this.type = type;
-
-  for (var option in options) {
-    if (!options.hasOwnProperty(option)) { continue; }
-
-    this[option] = options[option];
-  }
-};
-
-var indexOf = function(callbacks, callback) {
-  for (var i=0, l=callbacks.length; i<l; i++) {
-    if (callbacks[i][0] === callback) { return i; }
-  }
-
-  return -1;
-};
-
 var callbacksFor = function(object) {
   var callbacks = object._promiseCallbacks;
 
   if (!callbacks) {
-    callbacks = object._promiseCallbacks = {};
+    // pre-allocate shape
+    callbacks = object._promiseCallbacks = {
+      "promise:resolved": undefined,
+      "promise:failed": undefined,
+      "error": undefined
+    };
   }
 
   return callbacks;
@@ -31,62 +18,36 @@ var EventTarget = {
     object.on = this.on;
     object.off = this.off;
     object.trigger = this.trigger;
+    object._promiseCallbacks = undefined;
     return object;
   },
 
-  on: function(eventNames, callback, binding) {
-    var allCallbacks = callbacksFor(this), callbacks, eventName;
-    eventNames = eventNames.split(/\s+/);
-    binding = binding || this;
+  on: function(eventName, callback) {
+    var allCallbacks = callbacksFor(this), callbacks;
 
-    while (eventName = eventNames.shift()) {
-      callbacks = allCallbacks[eventName];
+    callbacks = allCallbacks[eventName];
 
-      if (!callbacks) {
-        callbacks = allCallbacks[eventName] = [];
-      }
-
-      if (indexOf(callbacks, callback) === -1) {
-        callbacks.push([callback, binding]);
-      }
+    if (!callbacks) {
+      callbacks = allCallbacks[eventName] = [];
     }
+
+    callbacks.push(callback);
   },
 
-  off: function(eventNames, callback) {
-    var allCallbacks = callbacksFor(this), callbacks, eventName, index;
-    eventNames = eventNames.split(/\s+/);
-
-    while (eventName = eventNames.shift()) {
-      if (!callback) {
-        allCallbacks[eventName] = [];
-        continue;
-      }
-
-      callbacks = allCallbacks[eventName];
-
-      index = indexOf(callbacks, callback);
-
-      if (index !== -1) { callbacks.splice(index, 1); }
-    }
+  off: function(eventName) {
+    var allCallbacks = callbacksFor(this);
+    allCallbacks[eventName] = [];
   },
 
   trigger: function(eventName, options) {
     var allCallbacks = callbacksFor(this),
-        callbacks, callbackTuple, callback, binding, event;
+        callbacks, callback;
 
     if (callbacks = allCallbacks[eventName]) {
       // Don't cache the callbacks.length since it may grow
       for (var i=0; i<callbacks.length; i++) {
-        callbackTuple = callbacks[i];
-        callback = callbackTuple[0];
-        binding = callbackTuple[1];
-
-        if (typeof options !== 'object') {
-          options = { detail: options };
-        }
-
-        event = new Event(eventName, options);
-        callback.call(binding, event);
+        callback = callbacks[i];
+        callback(options);
       }
     }
   }

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -33,9 +33,9 @@ var Promise = function(resolver) {
     reject(promise, value);
   };
 
-  this.on('promise:failed', function(event) {
-    this.trigger('error', { detail: event.detail });
-  }, this);
+  this.on('promise:failed', function(reason) {
+    promise.trigger('error', reason);
+  });
 
   this.on('error', onerror);
 
@@ -46,26 +46,26 @@ var Promise = function(resolver) {
   }
 };
 
-function onerror(event) {
+function onerror(reason) {
   if (config.onerror) {
-    config.onerror(event.detail);
+    config.onerror(reason);
   }
 }
 
-var invokeCallback = function(type, promise, callback, event) {
+var invokeCallback = function(type, promise, callback, detail) {
   var hasCallback = isFunction(callback),
       value, error, succeeded, failed;
 
   if (hasCallback) {
     try {
-      value = callback(event.detail);
+      value = callback(detail);
       succeeded = true;
     } catch(e) {
       failed = true;
       error = e;
     }
   } else {
-    value = event.detail;
+    value = detail;
     succeeded = true;
   }
 
@@ -97,23 +97,25 @@ Promise.prototype = {
 
     if (this.isFulfilled) {
       config.async(function(promise) {
-        invokeCallback('resolve', thenPromise, done, { detail: promise.fulfillmentValue });
+        invokeCallback('resolve', thenPromise, done, promise.fulfillmentValue);
       }, this);
     }
 
     if (this.isRejected) {
       config.async(function(promise) {
-        invokeCallback('reject', thenPromise, fail, { detail: promise.rejectedReason });
+        invokeCallback('reject', thenPromise, fail, promise.rejectedReason);
       }, this);
     }
 
-    this.on('promise:resolved', function(event) {
-      invokeCallback('resolve', thenPromise, done, event);
-    });
+    if (!this.isFulfilled && !this.isRejected) {
+      this.on('promise:resolved', function(event) {
+        invokeCallback('resolve', thenPromise, done, event);
+      });
 
-    this.on('promise:failed', function(event) {
-      invokeCallback('reject', thenPromise, fail, event);
-    });
+      this.on('promise:failed', function(event) {
+        invokeCallback('reject', thenPromise, fail, event);
+      });
+    }
 
     return thenPromise;
   },
@@ -175,7 +177,7 @@ function handleThenable(promise, value) {
 
 function fulfill(promise, value) {
   config.async(function() {
-    promise.trigger('promise:resolved', { detail: value });
+    promise.trigger('promise:resolved', value);
     promise.isFulfilled = true;
     promise.fulfillmentValue = value;
   });
@@ -183,7 +185,7 @@ function fulfill(promise, value) {
 
 function reject(promise, value) {
   config.async(function() {
-    promise.trigger('promise:failed', { detail: value });
+    promise.trigger('promise:failed', value);
     promise.isRejected = true;
     promise.rejectedReason = value;
   });


### PR DESCRIPTION
This includes:
- Removed support for multiple eventnames from `on` and `off`.
- Removed defensive code around duplicate event registrations.
- Removing an event removes all handlers for that event name --
  there is no longer a way to remove a specific event handler.
- Optimized object shape for the event target mixin.

These changes are all in the service of performance. We used
a slightly modified version of cujojs/promise-perf-tests to
benchmark, which runs in node. We've attached them below.

@stefanpenner / @lukemelia

~

```
> promise-perf-tests@0.3.2 test /Users/lmelia/p/promise-perf-tests
> ./bin/run.sh

==========================================================
Test: promise-fulfill x 10000
----------------------------------------------------------
Name      Time ms   Avg ms   Diff %
when           26   0.0026        -
q              43   0.0043    65.38
rsvp PR        90   0.0090   246.15
rsvp master    94   0.0094   261.54

==========================================================
Test: promise-reject x 10000
----------------------------------------------------------
Name      Time ms   Avg ms   Diff %
q              38   0.0038        -
when           48   0.0048    26.32
rsvp PR        66   0.0066    73.68
rsvp master   100   0.0100   163.16

==========================================================
Test: promise-sequence x 10000
----------------------------------------------------------
Name      Time ms   Avg ms   Diff %
when           82   0.0082        -
q             191   0.0191   132.93
rsvp PR       240   0.0240   192.68
rsvp master   411   0.0411   401.22

==========================================================
Test: defer-create x 100000
----------------------------------------------------------
Name      Time ms   Avg ms   Diff %
rsvp PR        76   0.0008        -
when          208   0.0021   173.68
q             243   0.0024   219.74
rsvp master   276   0.0028   263.16

==========================================================
Test: defer-fulfill x 10000
----------------------------------------------------------
Name      Time ms   Avg ms   Diff %
when           85   0.0085        -
rsvp PR       120   0.0120    41.18
rsvp master   206   0.0206   142.35
q             247   0.0247   190.59

==========================================================
Test: defer-reject x 10000
----------------------------------------------------------
Name      Time ms   Avg ms   Diff %
when           80   0.0080        -
rsvp PR       131   0.0131    63.75
rsvp master   203   0.0203   153.75
q             228   0.0228   185.00

==========================================================
Test: defer-sequence x 10000
----------------------------------------------------------
Name      Time ms   Avg ms   Diff %
when          127   0.0127        -
rsvp PR       214   0.0214    68.50
q             291   0.0291   129.13
rsvp master   433   0.0433   240.94
```
