### PR TITLE
fix bad test

### DIFF
--- a/test/tests/extension_test.js
+++ b/test/tests/extension_test.js
@@ -718,6 +718,7 @@ describe("RSVP extensions", function() {
         reject(thrownError);
       }).then(function() {
         // doesn't get here
+        assert(false);
       });
     });
 
@@ -752,12 +753,10 @@ describe("RSVP extensions", function() {
       var thrownError = new Error('I am an error.');
 
       function expectRejection(reason) {
-        done();
-        assertEqual(reason, thrownError);
+        assert.equal(reason, thrownError);
       }
 
       function doNotExpectFulfillment(value) {
-        done();
         assert(false, value);
       }
 
@@ -765,7 +764,8 @@ describe("RSVP extensions", function() {
 
       RSVP.reject(thrownError).
         fail(RSVP.rethrow).
-        then(doNotExpectFulfillment, expectRejection);
+        then(doNotExpectFulfillment, expectRejection).
+        then(done,done);
     });
   });
 


### PR DESCRIPTION
`done()` was called before the test's assertion, so nothing was being tested (and the test would have failed erroneously because `assertEqual` doesn't exist here).

Also another small change to cause a a test to fail if an unreachable spot gets hit.
