### PR TITLE
Add EventTarget based error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,16 +154,18 @@ are being 'swallowed', and not properly raised. This makes is extremely
 difficult to track down where a given issue is coming from. Thankfully,
 `RSVP` has a solution for this problem built in.
 
-You can provide an `onerror` function that will be called with the error
-details if any errors occur within your promise. This function can be anything
-but a common practice is to call `console.assert` to dump the error to the
-console.
+You can register functions to be called when an uncaught error occurs
+within your promises. These callback functions can be anything, but a common
+practice is to call `console.assert` to dump the error to the console.
 
 ```javascript
-RSVP.configure('onerror', function(error) {
-  console.assert(false, error);
+RSVP.on('error', function(event) {
+  console.assert(false, event.detail);
 });
 ```
+
+**NOTE:** Usage of `RSVP.configure('onerror', yourCustomFunction);` is
+deprecated in favor of using `RSVP.on`.
 
 ## Arrays of promises
 

--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -5,13 +5,9 @@ import { all } from "./rsvp/all";
 import { hash } from "./rsvp/hash";
 import { rethrow } from "./rsvp/rethrow";
 import { defer } from "./rsvp/defer";
-import { config } from "./rsvp/config";
+import { config, configure, on, off, trigger } from "./rsvp/config";
 import { resolve } from "./rsvp/resolve";
 import { reject } from "./rsvp/reject";
 import { async, asyncDefault } from "./rsvp/async";
 
-function configure(name, value) {
-  config[name] = value;
-}
-
-export { Promise, EventTarget, all, hash, rethrow, defer, denodeify, configure, resolve, reject, async, asyncDefault };
+export { Promise, EventTarget, all, hash, rethrow, defer, denodeify, configure, trigger, on, off, resolve, reject, async, asyncDefault };

--- a/lib/rsvp/config.js
+++ b/lib/rsvp/config.js
@@ -1,3 +1,31 @@
-var config = {};
+import { EventTarget } from "./events";
 
-export { config };
+var config = {};
+EventTarget.mixin(config);
+
+function configure(name, value) {
+  if (name === 'onerror') {
+    // handle for legacy users that expect the actual
+    // error to be passed to their function added via
+    // `RSVP.configure('onerror', someFunctionHere);`
+    config.on('error', function(event){
+      value(event.detail);
+    });
+  } else {
+    config[name] = value;
+  }
+}
+
+function on(){
+  return config.on.apply(config, arguments);
+}
+
+function off(){
+  return config.off.apply(config, arguments);
+}
+
+function trigger(){
+  return config.trigger.apply(config, arguments);
+}
+
+export { config, configure, on, off, trigger };

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -47,9 +47,7 @@ var Promise = function(resolver) {
 };
 
 function onerror(event) {
-  if (config.onerror) {
-    config.onerror(event.detail);
-  }
+  config.trigger('error', event);
 }
 
 var invokeCallback = function(type, promise, callback, event) {

--- a/test/tests/extension_test.js
+++ b/test/tests/extension_test.js
@@ -699,11 +699,48 @@ describe("RSVP extensions", function() {
     });
   });
 
+  describe("RSVP.on", function(){
+    after(function() {
+      RSVP.off('error');
+    });
+
+    it("When provided, any unhandled exceptions are sent to it", function(done) {
+      var thrownError = new Error();
+
+      RSVP.on('error', function(event) {
+        assert.equal(event.detail, thrownError, "The thrown error is passed in");
+        done();
+      });
+
+      new RSVP.Promise(function(resolve, reject) {
+        reject(thrownError);
+      }).then(function() {
+        // doesn't get here
+        assert(false);
+      });
+    });
+
+    it("When provided, handled exceptions are not sent to it", function(done) {
+      var thrownError = new Error();
+
+      RSVP.on('error', function(event) {
+        assert(false, "Should not get here");
+      });
+
+      new RSVP.Promise(function(resolve, reject) {
+        reject(thrownError);
+      }).then(null, function(error) {
+        assert.equal(error, thrownError, "The handler should handle the error");
+        done();
+      });
+    });
+  });
+
   describe("RSVP.onerror", function(){
     var onerror;
 
     after(function() {
-      RSVP.configure('onerror', null);
+      RSVP.off('error');
     });
 
     it("When provided, any unhandled exceptions are sent to it", function(done) {


### PR DESCRIPTION
Adds the ability to register multiple error handlers via `RSVP.on`:

``` javascript
RSVP.on('error', function(event) {
  console.assert(false, event);
});
```

Deprecates usage of `RSVP.configure('onerror', yourCustomFunction);`.

This also moves the `configure` function into `config.js` (which seems more appropriate).
