### PR TITLE
Perfs

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -11,8 +11,7 @@ function isFunction(x){
 }
 
 function Promise(resolver) {
-  var promise = this,
-  resolved = false;
+  var promise = this;
 
   if (typeof resolver !== 'function') {
     throw new TypeError('You must pass a resolver function as the sole argument to the promise constructor');
@@ -23,16 +22,14 @@ function Promise(resolver) {
   }
 
   var resolvePromise = function(value) {
-    if (resolved) { return; }
-    resolved = true;
     resolve(promise, value);
   };
 
   var rejectPromise = function(value) {
-    if (resolved) { return; }
-    resolved = true;
     reject(promise, value);
   };
+
+  this._subscribers = [];
 
   try {
     resolver(resolvePromise, rejectPromise);
@@ -41,20 +38,20 @@ function Promise(resolver) {
   }
 }
 
-var invokeCallback = function(type, promise, callback, event) {
+function invokeCallback(settled, promise, callback, detail) {
   var hasCallback = isFunction(callback),
       value, error, succeeded, failed;
 
   if (hasCallback) {
     try {
-      value = callback(event.detail);
+      value = callback(detail);
       succeeded = true;
     } catch(e) {
       failed = true;
       error = e;
     }
   } else {
-    value = event.detail;
+    value = detail;
     succeeded = true;
   }
 
@@ -64,20 +61,45 @@ var invokeCallback = function(type, promise, callback, event) {
     resolve(promise, value);
   } else if (failed) {
     reject(promise, error);
-  } else if (type === 'resolve') {
+  } else if (settled === FULFILLED) {
     resolve(promise, value);
-  } else if (type === 'reject') {
+  } else if (settled === REJECTED) {
     reject(promise, value);
   }
-};
+}
+
+var PENDING   = 0;
+var FULFILLED = 1;
+var REJECTED  = 2;
+
+function subscribe(parent, child, onFulfillment, onRejection) {
+  var subscribers = parent._subscribers;
+  var length = subscribers.length;
+
+  subscribers[length] = child;
+  subscribers[length + FULFILLED] = onFulfillment;
+  subscribers[length + REJECTED]  = onRejection;
+}
+
+function publish(promise, settled) {
+  var child, callback, subscribers = promise._subscribers, detail = promise._detail;
+
+  for (var i = 0; i < subscribers.length; i += 3) {
+    child = subscribers[i];
+    callback = subscribers[i + settled];
+
+    invokeCallback(settled, child, callback, detail);
+  }
+
+  promise._subscribers = null;
+}
 
 Promise.prototype = {
   constructor: Promise,
 
-  isRejected: undefined,
-  isFulfilled: undefined,
-  rejectedReason: undefined,
-  fulfillmentValue: undefined,
+  _state: undefined,
+  _detail: undefined,
+  _subscribers: undefined,
 
   _onerror: function (reason) {
     config.trigger('error', {
@@ -86,29 +108,19 @@ Promise.prototype = {
   },
 
   then: function(done, fail) {
+    var promise = this;
     this._onerror = null;
 
     var thenPromise = new this.constructor(function() {});
 
-    if (this.isFulfilled) {
-      config.async(function(promise) {
-        invokeCallback('resolve', thenPromise, done, { detail: promise.fulfillmentValue });
-      }, this);
+    if (this._state) {
+      var callbacks = arguments;
+      config.async(function() {
+        invokeCallback(promise._state, thenPromise, callbacks[promise._state - 1], promise._detail);
+      });
+    } else {
+      subscribe(this, thenPromise, done, fail);
     }
-
-    if (this.isRejected) {
-      config.async(function(promise) {
-        invokeCallback('reject', thenPromise, fail, { detail: promise.rejectedReason });
-      }, this);
-    }
-
-    this.on('promise:resolved', function(event) {
-      invokeCallback('resolve', thenPromise, done, event);
-    });
-
-    this.on('promise:failed', function(event) {
-      invokeCallback('reject', thenPromise, fail, event);
-    });
 
     return thenPromise;
   },
@@ -116,6 +128,7 @@ Promise.prototype = {
   fail: function(onRejection) {
     return this.then(null, onRejection);
   },
+
   'finally': function(callback) {
     var constructor = this.constructor;
 
@@ -133,16 +146,6 @@ Promise.prototype = {
 
 Promise.prototype['catch'] = Promise.prototype.fail;
 Promise.cast = cast;
-
-EventTarget.mixin(Promise.prototype);
-
-function resolve(promise, value) {
-  if (promise === value) {
-    fulfill(promise, value);
-  } else if (!handleThenable(promise, value)) {
-    fulfill(promise, value);
-  }
-}
 
 function handleThenable(promise, value) {
   var then = null,
@@ -177,6 +180,7 @@ function handleThenable(promise, value) {
       }
     }
   } catch (error) {
+    if (resolved) { return true; }
     reject(promise, error);
     return true;
   }
@@ -184,21 +188,40 @@ function handleThenable(promise, value) {
   return false;
 }
 
-function fulfill(promise, value) {
-  config.async(function() {
-    promise.trigger('promise:resolved', { detail: value });
-    promise.isFulfilled = true;
-    promise.fulfillmentValue = value;
-  });
+function resolve(promise, value) {
+  if (promise === value) {
+    fulfill(promise, value);
+  } else if (!handleThenable(promise, value)) {
+    fulfill(promise, value);
+  }
 }
 
-function reject(promise, value) {
-  config.async(function() {
-    if (promise._onerror) { promise._onerror(value); }
-    promise.trigger('promise:failed', { detail: value });
-    promise.isRejected = true;
-    promise.rejectedReason = value;
-  });
+function fulfill(promise, value) {
+  if (promise._state !== undefined) { return; }
+  promise._state = PENDING;
+  promise._detail = value;
+
+  config.async(publishFulfillment, promise);
+}
+
+function reject(promise, reason) {
+  if (promise._state !== undefined) { return; }
+  promise._state = PENDING;
+  promise._detail = reason;
+
+  config.async(publishRejection, promise);
+}
+
+function publishFulfillment(promise) {
+  publish(promise, promise._state = FULFILLED);
+}
+
+function publishRejection(promise) {
+  if (promise._onerror) {
+    promise._onerror(promise._detail);
+  }
+
+  publish(promise, promise._state = REJECTED);
 }
 
 export { Promise };

--- a/test/tests/extension_test.js
+++ b/test/tests/extension_test.js
@@ -518,15 +518,25 @@ describe("RSVP extensions", function() {
         firstResolver.reject({});
       }, 0);
 
-      setTimeout(function() {
-        secondResolver.resolve(true);
-      }, 5000);
+      var firstWasRejected, secondCompleted;
 
-      RSVP.hash({ first: first, second: second }).then(function() {
+      first.fail(function(){
+        firstWasRejected = true;
+      });
+
+      second['finally'](function(){
+        secondCompleted = true;
+      });
+
+      RSVP.hash({
+        first: first,
+        second: second
+      }).then(function() {
         assert(false);
+        done();
       }, function() {
-        assert(first.isRejected);
-        assert(!second.isResolved);
+        assert(firstWasRejected);
+        assert(!secondCompleted);
         done();
       });
     });
@@ -632,15 +642,21 @@ describe("RSVP extensions", function() {
         firstResolver.reject({});
       }, 0);
 
-      setTimeout(function() {
-        secondResolver.resolve(true);
-      }, 5000);
+      var firstWasRejected, secondCompleted;
+
+      first.fail(function(){
+        firstWasRejected = true;
+      });
+
+      second['finally'](function(){
+        secondCompleted = true;
+      });
 
       RSVP.all([first, second]).then(function() {
         assert(false);
       }, function() {
-        assert(first.isRejected);
-        assert(!second.isResolved);
+        assert(firstWasRejected);
+        assert(!secondCompleted);
         done();
       });
     });


### PR DESCRIPTION
Micro benchmarks FTW.

This is a bit ongoing, but i wanted to see how much juice I could squeeze out of RSVP, fun experiment.
Interestingly accordingly to these very important micro benchmarks, RSVP is now relatively quick. In node bluebird still often takes the lead (not to mention it likely has improved memory usage over RSVP) so we have some work todo. Interestingly in the browser, RSVP now comes up ahead, putting chrome's own native DOM Promises to shame.

notes to:  @petkaantonov before he gets worried
- (don't worry bluebird is still faster in node/IRL)
- yes the server side performance has more impact that client side.

using: https://github.com/stefanpenner/promise_benchmarks
side-note: I hope to add some more real-life scenarios to that benchmark suite.
- [x] basic benchmarks
- [x] initial easy improvements.
- [x] make travis happy. 
- [x] test in more browsers
- edited for fix bluebirds long stack traces being on in the browser build
  Chrome 33

``` log
Running Tests for Promise Creation ... promise_benchmarks.amd.js:330
- [Promise Creation] dom x 115,313 ops/sec ±7.25% (51 runs sampled)
- [Promise Creation] when x 5,383,836 ops/sec ±3.33% (59 runs sampled)
- [Promise Creation] bluebird x 6,447,872 ops/sec ±5.08% (56 runs sampled)
- [Promise Creation] rsvp-2.0.4 x 330,662 ops/sec ±6.79% (50 runs sampled)
- [Promise Creation] rsvp x 8,734,347 ops/sec ±7.02% (54 runs sampled)
Fastest for Promise Creation is ["rsvp"] promise_benchmarks.amd.js:288
Running Tests for Promise Rejection ... promise_benchmarks.amd.js:330
- [Promise Rejection] dom x 12,091 ops/sec ±5.05% (57 runs sampled)
- [Promise Rejection] when x 17,294 ops/sec ±6.48% (48 runs sampled)
- [Promise Rejection] bluebird x 18,681 ops/sec ±7.25% (52 runs sampled)
- [Promise Rejection] rsvp-2.0.4 x 12,704 ops/sec ±6.92% (53 runs sampled)
- [Promise Rejection] rsvp x 18,880 ops/sec ±8.70% (44 runs sampled)
Fastest for Promise Rejection is ["bluebird", "rsvp"] promise_benchmarks.amd.js:288
Running Tests for Promise Resolve: value ... promise_benchmarks.amd.js:330
- [Promise Resolve: value] dom x 12,991 ops/sec ±5.22% (56 runs sampled)
- [Promise Resolve: value] when x 17,248 ops/sec ±5.99% (47 runs sampled)
- [Promise Resolve: value] bluebird x 20,152 ops/sec ±4.77% (53 runs sampled)
- [Promise Resolve: value] rsvp-2.0.4 x 13,754 ops/sec ±5.36% (47 runs sampled)
- [Promise Resolve: value] rsvp x 23,168 ops/sec ±4.52% (52 runs sampled)
Fastest for Promise Resolve: value is ["rsvp"] promise_benchmarks.amd.js:288
Running Tests for Resolve Promise: promise ... promise_benchmarks.amd.js:330
- [Resolve Promise: promise] dom x 12,715 ops/sec ±3.86% (56 runs sampled)
- [Resolve Promise: promise] when x 18,345 ops/sec ±4.98% (50 runs sampled)
- [Resolve Promise: promise] bluebird x 21,023 ops/sec ±5.29% (53 runs sampled)
- [Resolve Promise: promise] rsvp-2.0.4 x 3,179 ops/sec ±27.57% (22 runs sampled)
- [Resolve Promise: promise] rsvp x 19,158 ops/sec ±5.41% (50 runs sampled)
Fastest for Resolve Promise: promise is ["bluebird"] promise_benchmarks.amd.js:288
Running Tests for Then Sequence 1 ... promise_benchmarks.amd.js:330
- [Then Sequence 1] dom x 15,474 ops/sec ±4.81% (53 runs sampled)
- [Then Sequence 1] when x 16,399 ops/sec ±6.11% (49 runs sampled)
- [Then Sequence 1] bluebird x 19,199 ops/sec ±4.49% (53 runs sampled)
- [Then Sequence 1] rsvp-2.0.4 x 3,749 ops/sec ±28.29% (31 runs sampled)
- [Then Sequence 1] rsvp x 19,569 ops/sec ±5.54% (48 runs sampled)
Fastest for Then Sequence 1 is ["rsvp", "bluebird"] promise_benchmarks.amd.js:288
Running Tests for Then Sequence 2 ... promise_benchmarks.amd.js:330
- [Then Sequence 2] dom x 14,056 ops/sec ±4.88% (55 runs sampled)
- [Then Sequence 2] when x 14,004 ops/sec ±5.84% (51 runs sampled)
- [Then Sequence 2] bluebird x 18,229 ops/sec ±6.76% (51 runs sampled)
- [Then Sequence 2] rsvp-2.0.4 x 3,493 ops/sec ±26.75% (29 runs sampled)
- [Then Sequence 2] rsvp x 18,707 ops/sec ±7.08% (48 runs sampled)
Fastest for Then Sequence 2 is ["rsvp", "bluebird"] promise_benchmarks.amd.js:288
Running Tests for Then Sequence 10 ... promise_benchmarks.amd.js:330
- [Then Sequence 10] dom x 12,347 ops/sec ±5.85% (59 runs sampled)
- [Then Sequence 10] when x 7,776 ops/sec ±10.67% (45 runs sampled)
- [Then Sequence 10] bluebird x 16,660 ops/sec ±6.54% (52 runs sampled)
- [Then Sequence 10] rsvp-2.0.4 x 4,277 ops/sec ±11.01% (40 runs sampled)
- [Then Sequence 10] rsvp x 15,345 ops/sec ±6.98% (49 runs sampled)
Fastest for Then Sequence 10 is ["bluebird", "rsvp"] promise_benchmarks.amd.js:288
Running Tests for Then Sequence 100 ... promise_benchmarks.amd.js:330
- [Then Sequence 100] dom x 4,075 ops/sec ±5.63% (54 runs sampled)
- [Then Sequence 100] when x 1,589 ops/sec ±14.34% (37 runs sampled)
- [Then Sequence 100] bluebird x 11,038 ops/sec ±8.42% (51 runs sampled)
- [Then Sequence 100] rsvp-2.0.4 x 568 ops/sec ±11.40% (43 runs sampled)
- [Then Sequence 100] rsvp x 4,914 ops/sec ±13.17% (47 runs sampled)
Fastest for Then Sequence 100 is ["bluebird"] 
```

Node v0.10.21

``` log
> promise_benchmarks@ start /Users/stefan/src/promise_benchmarks
> npm build && node index

Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Promise Creation ...
   - [Promise Creation] rsvp x 10,092,983 ops/sec ±1.69% (82 runs sampled)
   - [Promise Creation] rsvp-2.0.4 x 509,287 ops/sec ±2.39% (75 runs sampled)
   - [Promise Creation] bluebird x 5,984,504 ops/sec ±3.91% (75 runs sampled)
   - [Promise Creation] when x 5,750,027 ops/sec ±2.56% (78 runs sampled)
Fastest for Promise Creation is [ 'rsvp' ]


Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Promise Rejection ...
   - [Promise Rejection] rsvp x 54,269 ops/sec ±2.80% (64 runs sampled)
   - [Promise Rejection] rsvp-2.0.4 x 24,179 ops/sec ±4.22% (63 runs sampled)
   - [Promise Rejection] bluebird x 49,933 ops/sec ±3.87% (66 runs sampled)
   - [Promise Rejection] when x 39,552 ops/sec ±5.28% (54 runs sampled)
Fastest for Promise Rejection is [ 'rsvp' ]


Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Promise Resolve: value ...
   - [Promise Resolve: value] rsvp x 51,517 ops/sec ±3.24% (66 runs sampled)
   - [Promise Resolve: value] rsvp-2.0.4 x 26,344 ops/sec ±2.76% (58 runs sampled)
   - [Promise Resolve: value] bluebird x 53,605 ops/sec ±2.53% (66 runs sampled)
   - [Promise Resolve: value] when x 38,942 ops/sec ±2.84% (60 runs sampled)
Fastest for Promise Resolve: value is [ 'bluebird', 'rsvp' ]


Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Resolve Promise: promise ...
   - [Resolve Promise: promise] rsvp x 46,669 ops/sec ±1.86% (63 runs sampled)
   - [Resolve Promise: promise] rsvp-2.0.4 x 2,745 ops/sec ±45.04% (15 runs sampled)
   - [Resolve Promise: promise] bluebird x 44,776 ops/sec ±4.11% (64 runs sampled)
   - [Resolve Promise: promise] when x 33,140 ops/sec ±4.80% (58 runs sampled)
Fastest for Resolve Promise: promise is [ 'rsvp', 'bluebird' ]


Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Then Sequence 1 ...
   - [Then Sequence 1] rsvp x 48,692 ops/sec ±4.92% (52 runs sampled)
   - [Then Sequence 1] rsvp-2.0.4 x 3,023 ops/sec ±49.28% (13 runs sampled)
   - [Then Sequence 1] bluebird x 47,615 ops/sec ±5.30% (62 runs sampled)
   - [Then Sequence 1] when x 38,917 ops/sec ±7.27% (60 runs sampled)
Fastest for Then Sequence 1 is [ 'rsvp', 'bluebird' ]


Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Then Sequence 2 ...
   - [Then Sequence 2] rsvp x 43,842 ops/sec ±5.59% (60 runs sampled)
   - [Then Sequence 2] rsvp-2.0.4 x 2,765 ops/sec ±38.52% (18 runs sampled)
   - [Then Sequence 2] bluebird x 44,832 ops/sec ±11.06% (57 runs sampled)
   - [Then Sequence 2] when x 29,350 ops/sec ±9.32% (59 runs sampled)
Fastest for Then Sequence 2 is [ 'rsvp' ]


Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Then Sequence 10 ...
   - [Then Sequence 10] rsvp x 25,306 ops/sec ±15.29% (58 runs sampled)
   - [Then Sequence 10] rsvp-2.0.4 x 6,124 ops/sec ±15.31% (53 runs sampled)
   - [Then Sequence 10] bluebird x 42,072 ops/sec ±9.00% (62 runs sampled)
   - [Then Sequence 10] when x 10,591 ops/sec ±18.43% (35 runs sampled)
Fastest for Then Sequence 10 is [ 'bluebird' ]


Queueing Tests for rsvp, rsvp-2.0.4, bluebird, when ...
Running Tests for Then Sequence 100 ...
   - [Then Sequence 100] rsvp x 5,954 ops/sec ±15.62% (53 runs sampled)
   - [Then Sequence 100] rsvp-2.0.4 x 741 ops/sec ±14.78% (51 runs sampled)
   - [Then Sequence 100] bluebird x 21,832 ops/sec ±11.58% (69 runs sampled)
   - [Then Sequence 100] when x 880 ops/sec ±25.98% (27 runs sampled)
Fastest for Then Sequence 100 is [ 'bluebird' ]
```
