### PR TITLE
Adds Promise#race

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -2,6 +2,7 @@ import { EventTarget } from "./rsvp/events";
 import { Promise } from "./rsvp/promise";
 import { denodeify } from "./rsvp/node";
 import { all } from "./rsvp/all";
+import { race } from "./rsvp/race";
 import { hash } from "./rsvp/hash";
 import { rethrow } from "./rsvp/rethrow";
 import { defer } from "./rsvp/defer";
@@ -24,4 +25,12 @@ function off() {
   config.off.apply(config, arguments);
 }
 
-export { Promise, EventTarget, all, hash, rethrow, defer, denodeify, configure, resolve, reject, async, on, off };
+function trigger() {
+  config.trigger.apply(config, arguments);
+}
+
+Promise.on = on;
+Promise.off = off;
+Promise.trigger = trigger;
+
+export { Promise, EventTarget, all, race, hash, rethrow, defer, denodeify, configure, trigger, on, off, resolve, reject, async };

--- a/lib/rsvp/race.js
+++ b/lib/rsvp/race.js
@@ -1,0 +1,25 @@
+/* global toString */
+
+import { Promise } from "./promise";
+import { isArray } from "./utils";
+
+function race(promises, label) {
+  if (!isArray(promises)) {
+    throw new TypeError('You must pass an array to race.');
+  }
+  return new Promise(function(resolve, reject) {
+    var results = [], promise;
+
+    for (var i = 0; i < promises.length; i++) {
+      promise = promises[i];
+
+      if (promise && typeof promise.then === 'function') {
+        promise.then(resolve, reject, "RSVP: RSVP#race");
+      } else {
+        resolve(promise);
+      }
+    }
+  }, label);
+}
+
+export { race };


### PR DESCRIPTION
There's one failing test `resolves an empty array passed to RSVP.race()`. Domenic [commented](https://github.com/tildeio/rsvp.js/pull/102/files#r6185903) on [any PR](https://github.com/tildeio/rsvp.js/pull/102) saying that "if there are no promises, then there are no promises that ever satisfy your desire, so you should return a forever-pending promise." That's not how `all` works for example and I feel like we should be consistent.

Please correct me if I don't understand something here.

/cc @domenic
