### PR TITLE
Add instrumentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,26 @@ The example will work as expected. If you mix `RSVP.EventTarget` into a
 constructor's prototype, each instance of that constructor will get its
 own callbacks.
 
+## Instrumentation
+
+```js
+function listener (event) {
+  event.guid      // guid of promise
+  event.childGuid // child of child promise (for chained via `then`)
+  event.eventName // one of ['created', 'chained', 'fulfilled', 'rejected']
+  event.detail    // fulfillment value or rejection reason, if applicable
+  event.label     // label passed to promise's constructor
+}
+
+RSVP.Promise.on('created', listener);
+RSVP.Promise.on('chained', listener);
+RSVP.Promise.on('fulfilled', listener);
+RSVP.Promise.on('rejected', listener);
+```
+
+Events are only triggered when `RSVP.Promise.instrument` is true, although
+listeners can be registered at any time.
+
 ## Building & Testing
 
 This package uses the [grunt-microlib](https://github.com/thomasboyt/grunt-microlib) package for building.

--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -5,9 +5,25 @@ import { all } from "./rsvp/all";
 import { hash } from "./rsvp/hash";
 import { rethrow } from "./rsvp/rethrow";
 import { defer } from "./rsvp/defer";
-import { config, configure, on, off, trigger } from "./rsvp/config";
+import { config, configure } from "./rsvp/config";
 import { resolve } from "./rsvp/resolve";
 import { reject } from "./rsvp/reject";
 import { async, asyncDefault } from "./rsvp/async";
 
-export { Promise, EventTarget, all, hash, rethrow, defer, denodeify, configure, trigger, on, off, resolve, reject, async, asyncDefault };
+function on() {
+  config.on.apply(config, arguments);
+}
+
+function off() {
+  config.off.apply(config, arguments);
+}
+
+function trigger() {
+  config.trigger.apply(config, arguments);
+}
+
+Promise.on = on;
+Promise.off = off;
+Promise.trigger = trigger;
+
+export { Promise, EventTarget, all, hash, rethrow, defer, denodeify, configure, resolve, reject, async, asyncDefault, on, off };

--- a/lib/rsvp/all.js
+++ b/lib/rsvp/all.js
@@ -2,7 +2,7 @@
 
 import { Promise } from "./promise";
 
-function all(promises) {
+function all(promises, label) {
   if (Object.prototype.toString.call(promises) !== "[object Array]") {
     throw new TypeError('You must pass an array to all.');
   }
@@ -31,13 +31,13 @@ function all(promises) {
     for (var i = 0; i < promises.length; i++) {
       promise = promises[i];
 
-      if (promise && typeof promise === 'object' && typeof promise.then === 'function') {
-        promise.then(resolver(i), reject);
+      if (promise && typeof promise.then === 'function') {
+        promise.then(resolver(i), reject, "RSVP: RSVP#all");
       } else {
         resolveAll(i, promise);
       }
     }
-  });
+  }, label);
 }
 
 export { all };

--- a/lib/rsvp/config.js
+++ b/lib/rsvp/config.js
@@ -8,24 +8,10 @@ function configure(name, value) {
     // handle for legacy users that expect the actual
     // error to be passed to their function added via
     // `RSVP.configure('onerror', someFunctionHere);`
-    config.on('error', function(event){
-      value(event.detail);
-    });
+    config.on('error', value);
   } else {
     config[name] = value;
   }
 }
 
-function on(){
-  return config.on.apply(config, arguments);
-}
-
-function off(){
-  return config.off.apply(config, arguments);
-}
-
-function trigger(){
-  return config.trigger.apply(config, arguments);
-}
-
-export { config, configure, on, off, trigger };
+export { config, configure };

--- a/lib/rsvp/defer.js
+++ b/lib/rsvp/defer.js
@@ -1,6 +1,6 @@
 import { Promise } from "./promise";
 
-function defer() {
+function defer(label) {
   var deferred = {
     // pre-allocate shape
     resolve: undefined,
@@ -11,7 +11,7 @@ function defer() {
   deferred.promise = new Promise(function(resolve, reject) {
     deferred.resolve = resolve;
     deferred.reject = reject;
-  });
+  }, label);
 
   return deferred;
 }

--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -1,13 +1,3 @@
-var Event = function(type, options) {
-  this.type = type;
-
-  for (var option in options) {
-    if (!options.hasOwnProperty(option)) { continue; }
-
-    this[option] = options[option];
-  }
-};
-
 var indexOf = function(callbacks, callback) {
   for (var i=0, l=callbacks.length; i<l; i++) {
     if (callbacks[i][0] === callback) { return i; }
@@ -31,62 +21,49 @@ var EventTarget = {
     object.on = this.on;
     object.off = this.off;
     object.trigger = this.trigger;
+    object._promiseCallbacks = undefined;
     return object;
   },
 
-  on: function(eventNames, callback, binding) {
-    var allCallbacks = callbacksFor(this), callbacks, eventName;
-    eventNames = eventNames.split(/\s+/);
-    binding = binding || this;
+  on: function(eventName, callback) {
+    var allCallbacks = callbacksFor(this), callbacks;
 
-    while (eventName = eventNames.shift()) {
-      callbacks = allCallbacks[eventName];
+    callbacks = allCallbacks[eventName];
 
-      if (!callbacks) {
-        callbacks = allCallbacks[eventName] = [];
-      }
+    if (!callbacks) {
+      callbacks = allCallbacks[eventName] = [];
+    }
 
-      if (indexOf(callbacks, callback) === -1) {
-        callbacks.push([callback, binding]);
-      }
+    if (indexOf(callbacks, callback) === -1) {
+      callbacks.push(callback);
     }
   },
 
-  off: function(eventNames, callback) {
-    var allCallbacks = callbacksFor(this), callbacks, eventName, index;
-    eventNames = eventNames.split(/\s+/);
+  off: function(eventName, callback) {
+    var allCallbacks = callbacksFor(this), callbacks, index;
 
-    while (eventName = eventNames.shift()) {
-      if (!callback) {
-        allCallbacks[eventName] = [];
-        continue;
-      }
-
-      callbacks = allCallbacks[eventName];
-
-      index = indexOf(callbacks, callback);
-
-      if (index !== -1) { callbacks.splice(index, 1); }
+    if (!callback) {
+      allCallbacks[eventName] = [];
+      return;
     }
+
+    callbacks = allCallbacks[eventName];
+
+    index = indexOf(callbacks, callback);
+
+    if (index !== -1) { callbacks.splice(index, 1); }
   },
 
   trigger: function(eventName, options) {
     var allCallbacks = callbacksFor(this),
-        callbacks, callbackTuple, callback, binding, event;
+        callbacks, callbackTuple, callback, binding;
 
     if (callbacks = allCallbacks[eventName]) {
       // Don't cache the callbacks.length since it may grow
       for (var i=0; i<callbacks.length; i++) {
-        callbackTuple = callbacks[i];
-        callback = callbackTuple[0];
-        binding = callbackTuple[1];
+        callback = callbacks[i];
 
-        if (typeof options !== 'object') {
-          options = { detail: options };
-        }
-
-        event = new Event(eventName, options);
-        callback.call(binding, event);
+        callback(options);
       }
     }
   }

--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -10,7 +10,7 @@ var keysOf = Object.keys || function(object) {
   return result;
 };
 
-function hash(object) {
+function hash(object, label) {
   var results = {},
       keys = keysOf(object),
       remaining = keys.length;
@@ -42,7 +42,7 @@ function hash(object) {
       promise = object[prop];
 
       if (promise && typeof promise.then === 'function') {
-        promise.then(resolver(prop), reject);
+        promise.then(resolver(prop), reject, "RSVP: RSVP#hash");
       } else {
         resolveAll(prop, promise);
       }

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -10,7 +10,10 @@ function isFunction(x){
   return typeof x === "function";
 }
 
-function Promise(resolver) {
+var guidKey = 'rsvp_' + new Date().getTime() + '-'; 
+var promiseIndex = 0;
+
+function Promise(resolver, label) {
   var promise = this;
 
   if (typeof resolver !== 'function') {
@@ -21,6 +24,8 @@ function Promise(resolver) {
     throw new TypeError("Failed to construct 'Promise': Please use the 'new' operator, this object constructor cannot be called as a function.");
   }
 
+  this._label = label;
+
   var resolvePromise = function(value) {
     resolve(promise, value);
   };
@@ -30,6 +35,11 @@ function Promise(resolver) {
   };
 
   this._subscribers = [];
+  this._guid = guidKey + promiseIndex++;
+
+  if (Promise.instrument) {
+    instrument('created', promise);
+  }
 
   try {
     resolver(resolvePromise, rejectPromise);
@@ -68,7 +78,8 @@ function invokeCallback(settled, promise, callback, detail) {
   }
 }
 
-var PENDING   = 0;
+var PENDING   = void 0;
+var SEALED    = 0;
 var FULFILLED = 1;
 var REJECTED  = 2;
 
@@ -84,6 +95,10 @@ function subscribe(parent, child, onFulfillment, onRejection) {
 function publish(promise, settled) {
   var child, callback, subscribers = promise._subscribers, detail = promise._detail;
 
+  if (Promise.instrument) {
+    instrument(settled === FULFILLED ? 'fulfilled' : 'rejected', promise);
+  }
+
   for (var i = 0; i < subscribers.length; i += 3) {
     child = subscribers[i];
     callback = subscribers[i + settled];
@@ -95,6 +110,8 @@ function publish(promise, settled) {
 }
 
 Promise.prototype = {
+  _guid: undefined,
+  _label: undefined,
   constructor: Promise,
 
   _state: undefined,
@@ -102,16 +119,20 @@ Promise.prototype = {
   _subscribers: undefined,
 
   _onerror: function (reason) {
-    config.trigger('error', {
-      detail: reason
-    });
+    try {
+      Promise.trigger('error', reason);
+    } catch(error) {
+      setTimeout(function(){
+        throw error;
+      }, 0);
+    }
   },
 
-  then: function(done, fail) {
+  then: function(done, fail, label) {
     var promise = this;
     this._onerror = null;
 
-    var thenPromise = new this.constructor(function() {});
+    var thenPromise = new this.constructor(function() {}, label);
 
     if (this._state) {
       var callbacks = arguments;
@@ -122,11 +143,15 @@ Promise.prototype = {
       subscribe(this, thenPromise, done, fail);
     }
 
+    if (Promise.instrument) {
+      instrument('chained', promise, thenPromise);
+    }
+
     return thenPromise;
   },
 
-  fail: function(onRejection) {
-    return this.then(null, onRejection);
+  fail: function(onRejection, label) {
+    return this.then(null, onRejection, label);
   },
 
   'finally': function(callback) {
@@ -146,6 +171,25 @@ Promise.prototype = {
 
 Promise.prototype['catch'] = Promise.prototype.fail;
 Promise.cast = cast;
+
+EventTarget.mixin(Promise); // instrumentation
+
+function instrument(eventName, promise, child) {
+  // instrumentation should not disrupt normal usage.
+  try {
+    config.trigger(eventName, {
+      guid: promise._guid,
+      eventName: eventName,
+      detail: promise._detail,
+      childGuid: child && child._guid,
+      label: promise._label
+    });
+  } catch(error) {
+    setTimeout(function(){
+      throw error;
+    }, 0);
+  }
+}
 
 function handleThenable(promise, value) {
   var then = null,
@@ -174,7 +218,7 @@ function handleThenable(promise, value) {
           resolved = true;
 
           reject(promise, val);
-        });
+        }, 'Locked onto ' + (promise._label || ' unknown promise'));
 
         return true;
       }
@@ -197,16 +241,16 @@ function resolve(promise, value) {
 }
 
 function fulfill(promise, value) {
-  if (promise._state !== undefined) { return; }
-  promise._state = PENDING;
+  if (promise._state !== PENDING) { return; }
+  promise._state = SEALED;
   promise._detail = value;
 
   config.async(publishFulfillment, promise);
 }
 
 function reject(promise, reason) {
-  if (promise._state !== undefined) { return; }
-  promise._state = PENDING;
+  if (promise._state !== PENDING) { return; }
+  promise._state = SEALED;
   promise._detail = reason;
 
   config.async(publishRejection, promise);

--- a/lib/rsvp/reject.js
+++ b/lib/rsvp/reject.js
@@ -1,9 +1,9 @@
 import { Promise } from "./promise";
 
-function reject(reason) {
+function reject(reason, label) {
   return new Promise(function (resolve, reject) {
     reject(reason);
-  });
+  }, label);
 }
 
 export { reject };

--- a/lib/rsvp/resolve.js
+++ b/lib/rsvp/resolve.js
@@ -1,9 +1,9 @@
 import { Promise } from "./promise";
 
-function resolve(thenable) {
+function resolve(thenable, label) {
   return new Promise(function(resolve, reject) {
     resolve(thenable);
-  });
+  }, label);
 }
 
 export { resolve };


### PR DESCRIPTION
``` js
function listener (event) {
 event.guid            // guid of promise
 event.childGuid       // guid of child promise (for chained via `then`)
 event.eventName       // one of ['created', 'chained', 'fulfilled', 'rejected']
 event.detail          // fulfillment value or rejection reason, if applicable
 event.label           // label passed to promise's constructor
}

RSVP.Promise.on('created', listener);
RSVP.Promise.on('chained', listener); 
RSVP.Promise.on('fulfilled', listener);
RSVP.Promise.on('rejected', listener);
```

Events are only triggered when `RSVP.Promise.instrument` is true, although 
listeners can be registered at any time.

@hjdivad & @stefanpenner
