### PR TITLE
Add timeStamp to instrumentation event

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ function listener (event) {
   event.eventName // one of ['created', 'chained', 'fulfilled', 'rejected']
   event.detail    // fulfillment value or rejection reason, if applicable
   event.label     // label passed to promise's constructor
+  event.timeStamp // milliseconds elapsed since 1 January 1970 00:00:00 UTC up until now
 }
 
 RSVP.Promise.on('created', listener);

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -176,6 +176,10 @@ Promise.instrument = false;
 
 EventTarget.mixin(Promise); // instrumentation
 
+// Date.now is not available in browsers < IE9
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now#Compatibility
+var now = Date.now || function() { return new Date().getTime(); };
+
 function instrument(eventName, promise, child) {
   // instrumentation should not disrupt normal usage.
   try {
@@ -184,7 +188,8 @@ function instrument(eventName, promise, child) {
       eventName: eventName,
       detail: promise._detail,
       childGuid: child && promise._guidKey + child._id,
-      label: promise._label
+      label: promise._label,
+      timeStamp: now()
     });
   } catch(error) {
     setTimeout(function(){

--- a/test/tests/extension_test.js
+++ b/test/tests/extension_test.js
@@ -1216,6 +1216,10 @@ describe("RSVP extensions", function() {
           assert(parsedGuid.key, 'has a key');
           assert(parsedGuid.index, 'has a count');
 
+          assert.equal(event.eventName, 'created');
+          assert(event.timeStamp, 'has a timeStamp');
+          assert.ok(!event.detail, 'a created event has no detail');
+
           done();
         });
 
@@ -1258,8 +1262,11 @@ describe("RSVP extensions", function() {
           rejectionCount++;
           assert.equal(rejectionCount, 1, 'emitted the rejection event only once');
 
+          assert.equal(event.eventName, 'rejected');
           assert(event.guid, 'has a guid');
           assert.equal(event.detail, reason, 'correct rejection reason');
+          assert(event.timeStamp, 'has a timeStamp');
+
           done();
         });
 
@@ -1280,8 +1287,11 @@ describe("RSVP extensions", function() {
           fulfillmentCount++;
           assert.equal(fulfillmentCount, 1, 'emitted the fulfilment event only once');
 
+          assert.equal(event.eventName, 'fulfilled');
           assert(event.guid, 'has a guid');
           assert.equal(event.detail, value, 'correct fulfillment value');
+          assert(event.timeStamp, 'has a timeStamp');
+
           done();
         });
 
@@ -1315,6 +1325,9 @@ describe("RSVP extensions", function() {
 
           assert(parsedChild.key);
           assert(parsedChild.index);
+
+          assert.equal(event.eventName, 'chained');
+          assert(event.timeStamp, 'has a timeStamp');
 
           done();
         });


### PR DESCRIPTION
The timeStamp holds the UTC UNIX timestamp when the instrumentation
event has been created.

If merged, this would close #138.
