### PR TITLE
Add everything not-useful to .npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,12 @@
 /node_modules/
 /tmp
+/lib
+/tasks
+/test
+/vendor
+/.jshintrc
+/.npmignore
+/.travis.yml
+/Gruntfile.js
+/component.json
+/index.html


### PR DESCRIPTION
Currently pulling down RSVP from npm installs a bunch of dotfiles and build/test stuff. With this change you just get dist/, CHANGELOG.md, LICENSE, README.md, and package.json.
