### PR TITLE
Use connect-redirection instead of root-level index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-<a href="/test/index.html">Tests</a>

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "load-grunt-config": "~0.5.0",
     "load-grunt-tasks": "~0.2.0",
     "mocha-phantomjs": "~3.1.6",
-    "promises-aplus-tests": "git://github.com/stefanpenner/promises-tests.git"
+    "promises-aplus-tests": "git://github.com/stefanpenner/promises-tests.git",
+    "connect-redirection": "0.0.1"
   },
   "scripts": {
     "test": "grunt test",

--- a/tasks/options/connect.js
+++ b/tasks/options/connect.js
@@ -4,6 +4,20 @@ module.exports = {
   options: {
     hostname: '0.0.0.0',
     port: (process.env.PORT || 8000),
-    base: '.'
+    base: '.',
+    middleware: function(connect, options) {
+      return [
+        require('connect-redirection')(),
+        function(req, res, next) {
+          if (req.url === '/') {
+            res.redirect('/test');
+          } else {
+            next();
+          }
+        },
+        connect.static(options.base)
+      ];
+    }
+
   }
 };


### PR DESCRIPTION
Navigating to localhost:8000 will redirect
to localhost:8000/test using connect middleware
vs. top level index.html with a link
