### PR TITLE
fix @returns to be @return for yuidocs

### DIFF
--- a/lib/rsvp/all.js
+++ b/lib/rsvp/all.js
@@ -43,7 +43,7 @@ import { isArray, isFunction } from "./utils";
   @for RSVP
   @param {Array} promises
   @param {String} label
-  @returns {Promise} promise that is fulfilled when all `promises` have been
+  @return {Promise} promise that is fulfilled when all `promises` have been
   fulfilled, or rejected if any of them become rejected.
 */
 function all(promises, label) {

--- a/lib/rsvp/defer.js
+++ b/lib/rsvp/defer.js
@@ -29,7 +29,7 @@ import { Promise } from "./promise";
   @method defer
   @for RSVP
   @param {String} -
-  @returns {Object}
+  @return {Object}
  */
 
 function defer(label) {

--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -94,7 +94,7 @@ var keysOf = Object.keys || function(object) {
   @param {Object} promises
   @param {String} label - optional string that describes the promise.
   Useful for tooling.
-  @returns {Promise} promise that is fulfilled when all properties of `promises`
+  @return {Promise} promise that is fulfilled when all properties of `promises`
   have been fulfilled, or rejected if any of them become rejected.
 */
 function hash(object, label) {

--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -87,7 +87,7 @@ function makeNodeCallbackFor(resolve, reject) {
   operation as its second argument ("function(err, value){ }").
   @param {Any} binding optional argument for binding the "this" value when
   calling the `nodeFunc` function.
-  @returns {Function} a function that wraps `nodeFunc` to return an
+  @return {Function} a function that wraps `nodeFunc` to return an
   `RSVP.Promise`
 */
 function denodeify(nodeFunc, binding) {

--- a/lib/rsvp/race.js
+++ b/lib/rsvp/race.js
@@ -60,7 +60,7 @@ import { isArray } from "./utils";
   @param {Array} promises array of promises to observe
   @param {String} label optional string for describing the promise returned.
   Useful for tooling.
-  @returns {Promise} a promise that becomes fulfilled with the value the first
+  @return {Promise} a promise that becomes fulfilled with the value the first
   completed promises is resolved with if the first completed promise was
   fulfilled, or rejected with the reason that the first completed promise
   was rejected with.

--- a/lib/rsvp/reject.js
+++ b/lib/rsvp/reject.js
@@ -34,7 +34,7 @@ import { Promise } from "./promise";
   @param {Any} reason value that the returned promise will be rejected with.
   @param {String} label optional string for identifying the returned promise.
   Useful for tooling.
-  @returns {Promise} a promise that will become rejected with the given
+  @return {Promise} a promise that will become rejected with the given
   `reason`.
 */
 function reject(reason, label) {

--- a/lib/rsvp/resolve.js
+++ b/lib/rsvp/resolve.js
@@ -30,7 +30,7 @@ import { Promise } from "./promise";
   @param {Any} value value that the returned promise will be resolved with
   @param {String} label optional string for identifying the returned promise.
   Useful for tooling.
-  @returns {Promise} a promise that will become fulfilled with the given
+  @return {Promise} a promise that will become fulfilled with the given
   `value`
 */
 function resolve(value, label) {


### PR DESCRIPTION
see example at http://yui.github.io/yuidoc/syntax/#return and screenshot of yuidoc output on doc generation:

![terminal__zsh__16040_and_yuidoc_-_javascript_documentation_tool](https://f.cloud.github.com/assets/514063/1659887/8c6f4dd2-5bad-11e3-84fa-250bdb048a4b.png)
