### PR TITLE
fix all examples to conform with yuidoc example syntax

### DIFF
--- a/lib/rsvp/all.js
+++ b/lib/rsvp/all.js
@@ -9,35 +9,32 @@ import { isArray, isFunction } from "./utils";
   is fulfilled with an array that gives all the values in the order they were
   passed in the `promises` array argument.
 
-  For example:
+  Example:
 
-  ```javascript
-  var promise1 = RSVP.resolve(1);
-  var promise2 = RSVP.resolve(2);
-  var promise3 = RSVP.resolve(3);
-  var promises = [ promise1, promise2, promise3 ];
+      var promise1 = RSVP.resolve(1);
+      var promise2 = RSVP.resolve(2);
+      var promise3 = RSVP.resolve(3);
+      var promises = [ promise1, promise2, promise3 ];
 
-  RSVP.all(promises).then(function(array){
-    // The array here would be [ 1, 2, 3 ];
-  });
-  ```
+      RSVP.all(promises).then(function(array){
+        // The array here would be [ 1, 2, 3 ];
+      });
 
   If any of the `promises` given to `RSVP.all` are rejected, the first promise
   that is rejected will be given as an argument to the returned promises's
   rejection handler. For example:
 
-  ```javascript
-  var promise1 = RSVP.resolve(1);
-  var promise2 = RSVP.reject(new Error("2"));
-  var promise3 = RSVP.reject(new Error("3"));
-  var promises = [ promise1, promise2, promise3 ];
+  Example:
+      var promise1 = RSVP.resolve(1);
+      var promise2 = RSVP.reject(new Error("2"));
+      var promise3 = RSVP.reject(new Error("3"));
+      var promises = [ promise1, promise2, promise3 ];
 
-  RSVP.all(promises).then(function(array){
-    // Code here never runs because there are rejected promises!
-  }, function(error) {
-    // error.message === "2"
-  });
-  ```
+      RSVP.all(promises).then(function(array){
+        // Code here never runs because there are rejected promises!
+      }, function(error) {
+        // error.message === "2"
+      });
 
   @method all
   @for RSVP

--- a/lib/rsvp/cast.js
+++ b/lib/rsvp/cast.js
@@ -3,12 +3,11 @@
   with the promise being casted.
 
   Example:
-  ```javascript
-  var promise = RSVP.resolve(1);
-  var casted = RSVP.Promise.cast(promise);
 
-  console.log(promise === casted); // true
-  ```
+      var promise = RSVP.resolve(1);
+      var casted = RSVP.Promise.cast(promise);
+
+      console.log(promise === casted); // true
 
   In the case of a promise whose constructor does not match, it is assimilated.
   The resulting promise will fulfill or reject based on the outcome of the
@@ -18,17 +17,16 @@
   returned.
 
   Example:
-  ```javascript
-  var value = 1; // could be a number, boolean, string, undefined...
-  var casted = RSVP.Promise.cast(value);
 
-  console.log(value === casted); // false
-  console.log(casted instanceof RSVP.Promise) // true
+      var value = 1; // could be a number, boolean, string, undefined...
+      var casted = RSVP.Promise.cast(value);
 
-  casted.then(function(val) {
-    val === value // => true
-  });
-  ```
+      console.log(value === casted); // false
+      console.log(casted instanceof RSVP.Promise) // true
+
+      casted.then(function(val) {
+        val === value // => true
+      });
 
   `RSVP.Promise.Cast` is similar to `RSVP.resolve`, but `RSVP.Promise.Cast` differs in the
   following ways:

--- a/lib/rsvp/defer.js
+++ b/lib/rsvp/defer.js
@@ -15,16 +15,13 @@ import { Promise } from "./promise";
 
   Example:
 
-  ```javascript
+      var deferred = RSVP.defer();
 
-  var deferred = RSVP.defer();
+      deferred.resolve("Success!");
 
-  deferred.resolve("Success!");
-
-  defered.promise.then(function(value){
-    // value here is "Success!"
-  });
-  ```
+      defered.promise.then(function(value){
+        // value here is "Success!"
+      });
 
   @method defer
   @for RSVP

--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -25,40 +25,38 @@ var EventTarget = {
   /**
     @private
     `RSVP.EventTarget.mixin` extends an object with EventTarget methods. For
-    example:
+    Example:
 
-    ```javascript
-    var object = {};
+        var object = {};
 
-    RSVP.EventTarget.mixin(object);
+        RSVP.EventTarget.mixin(object);
 
-    object.on("finished", function(event) {
-      // handle event
-    });
+        object.on("finished", function(event) {
+          // handle event
+        });
 
-    object.trigger("finished", { detail: value });
-    ```
+        object.trigger("finished", { detail: value });
+
 
     `EventTarget.mixin` also works with prototypes:
 
-    ```javascript
-    var Person = function() {};
-    RSVP.EventTarget.mixin(Person.prototype);
 
-    var yehuda = new Person();
-    var tom = new Person();
+        var Person = function() {};
+        RSVP.EventTarget.mixin(Person.prototype);
 
-    yehuda.on("poke", function(event) {
-      console.log("Yehuda says OW");
-    });
+        var yehuda = new Person();
+        var tom = new Person();
 
-    tom.on("poke", function(event) {
-      console.log("Tom says OW");
-    });
+        yehuda.on("poke", function(event) {
+          console.log("Yehuda says OW");
+        });
 
-    yehuda.trigger("poke");
-    tom.trigger("poke");
-    ```
+        tom.on("poke", function(event) {
+          console.log("Tom says OW");
+        });
+
+        yehuda.trigger("poke");
+        tom.trigger("poke");
 
     @method mixin
     @param {Object} object object to extend with EventTarget methods
@@ -75,14 +73,12 @@ var EventTarget = {
     @private
 
     Registers a callback to be executed when `eventName` is triggered
-    ```javascript
 
-    object.on('event', function(eventInfo){
-      // handle the event
-    });
+        object.on('event', function(eventInfo){
+          // handle the event
+        });
 
-    object.trigger('event');
-    ```
+        object.trigger('event');
 
     @method on
     @param {String} eventName name of the event to listen for
@@ -107,33 +103,30 @@ var EventTarget = {
 
     You can use `off` to stop firing a particular callback for an event:
 
-    ```javascript
-    function doStuff() { // do stuff! }
-    object.on('stuff', doStuff);
+        function doStuff() { // do stuff! }
+        object.on('stuff', doStuff);
 
-    object.trigger('stuff'); // doStuff will be called
+        object.trigger('stuff'); // doStuff will be called
 
-    // Unregister ONLY the doStuff callback
-    object.off('stuff', doStuff);
-    object.trigger('stuff'); // doStuff will NOT be called
+        // Unregister ONLY the doStuff callback
+        object.off('stuff', doStuff);
+        object.trigger('stuff'); // doStuff will NOT be called
 
-    ```
 
     If you don't pass a `callback` argument to `off`, ALL callbacks for the
     event will not be executed when the event fires. For example:
 
-    ```javascript
-    var callback1 = function(){};
-    var callback2 = function(){};
 
-    object.on('stuff', callback1);
-    object.on('stuff', callback2);
+        var callback1 = function(){};
+        var callback2 = function(){};
 
-    object.trigger('stuff'); // callback1 and callback2 will be executed.
+        object.on('stuff', callback1);
+        object.on('stuff', callback2);
 
-    object.off('stuff');
-    object.trigger('stuff'); // callback1 and callback2 will not be executed!
-    ```
+        object.trigger('stuff'); // callback1 and callback2 will be executed.
+
+        object.off('stuff');
+        object.trigger('stuff'); // callback1 and callback2 will not be executed!
 
     @method off
     @param {String} eventName event to stop listening to
@@ -162,25 +155,22 @@ var EventTarget = {
 
     Use `trigger` to fire custom events. For example:
 
-    ```javascript
-    object.on('foo', function(){
-      console.log('foo event happened!');
-    });
-    object.trigger('foo');
-    // 'foo event happened!' logged to the console
-    ```
+        object.on('foo', function(){
+          console.log('foo event happened!');
+        });
+        object.trigger('foo');
+        // 'foo event happened!' logged to the console
+
 
     You can also pass a value as a second argument to `trigger` that will be
     passed as an argument to all event listeners for the event:
 
-    ```javascript
-    object.on('foo', function(value){
-      console.log(value.name);
-    });
+        object.on('foo', function(value){
+          console.log(value.name);
+        });
 
-    object.trigger('foo', { name: 'bar' });
-    // 'bar' logged to the console
-    ```
+        object.trigger('foo', { name: 'bar' });
+        // 'bar' logged to the console
 
     @method trigger
     @param {String} eventName name of the event to be triggered

--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -21,73 +21,67 @@ var keysOf = Object.keys || function(object) {
   argument. If any of the values in the object are not promises, they will
   simply be copied over to the fulfilled object.
 
-  For example:
+  Example:
 
-  ```javascript
-  var promises = {
-    myPromise: RSVP.resolve(1),
-    yourPromise: RSVP.resolve(2),
-    theirPromise: RSVP.resolve(3),
-    notAPromise: 4
-  };
+      var promises = {
+        myPromise: RSVP.resolve(1),
+        yourPromise: RSVP.resolve(2),
+        theirPromise: RSVP.resolve(3),
+        notAPromise: 4
+      };
 
-  RSVP.hash(promises).then(function(hash){
-    // hash here is an object that looks like:
-    // {
-    //   myPromise: 1,
-    //   yourPromise: 2,
-    //   theirPromise: 3,
-    //   notAPromise: 4
-    // }
-  });
-  ```
+      RSVP.hash(promises).then(function(hash){
+        // hash here is an object that looks like:
+        // {
+        //   myPromise: 1,
+        //   yourPromise: 2,
+        //   theirPromise: 3,
+        //   notAPromise: 4
+        // }
+      });
 
   If any of the `promises` given to `RSVP.hash` are rejected, the first promise
   that is rejected will be given as as the first argument, or as the reason to
   the rejection handler. For example:
 
-  ```javascript
-  var promises = {
-    myPromise: RSVP.resolve(1),
-    rejectedPromise: RSVP.reject(new Error("rejectedPromise")),
-    anotherRejectedPromise: RSVP.reject(new Error("anotherRejectedPromise")),
-  };
+      var promises = {
+        myPromise: RSVP.resolve(1),
+        rejectedPromise: RSVP.reject(new Error("rejectedPromise")),
+        anotherRejectedPromise: RSVP.reject(new Error("anotherRejectedPromise")),
+      };
 
-  RSVP.hash(promises).then(function(hash){
-    // Code here never runs because there are rejected promises!
-  }, function(reason) {
-    // reason.message === "rejectedPromise"
-  });
-  ```
+      RSVP.hash(promises).then(function(hash){
+        // Code here never runs because there are rejected promises!
+      }, function(reason) {
+        // reason.message === "rejectedPromise"
+      });
 
   An important note: `RSVP.hash` is intended for plain JavaScript objects that
   are just a set of keys and values. `RSVP.hash` will NOT preserve prototype
   chains.
 
-  For example:
+  Example:
 
-  ```javascript
-  function MyConstructor(){
-    this.example = RSVP.resolve("Example");
-  }
+      function MyConstructor(){
+        this.example = RSVP.resolve("Example");
+      }
 
-  MyConstructor.prototype = {
-    protoProperty: RSVP.resolve("Proto Property")
-  };
+      MyConstructor.prototype = {
+        protoProperty: RSVP.resolve("Proto Property")
+      };
 
-  var myObject = new MyConstructor();
+      var myObject = new MyConstructor();
 
-  RSVP.hash(myObject).then(function(hash){
-    // protoProperty will not be present, instead you will just have an
-    // object that looks like:
-    // {
-    //   example: "Example"
-    // }
-    //
-    // hash.hasOwnProperty('protoProperty'); // false
-    // 'undefined' === typeof hash.protoProperty
-  });
-  ```
+      RSVP.hash(myObject).then(function(hash){
+        // protoProperty will not be present, instead you will just have an
+        // object that looks like:
+        // {
+        //   example: "Example"
+        // }
+        //
+        // hash.hasOwnProperty('protoProperty'); // false
+        // 'undefined' === typeof hash.protoProperty
+      });
 
   @method hash
   @for RSVP

--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -21,63 +21,57 @@ function makeNodeCallbackFor(resolve, reject) {
   browser when you'd prefer to use promises over using callbacks. For example,
   `denodeify` transforms the following:
 
-  ```javascript
-  var fs = require('fs');
+      var fs = require('fs');
 
-  fs.readFile('myfile.txt', function(err, data){
-    if (err) return handleError(err);
-    handleData(data);
-  });
-  ```
+      fs.readFile('myfile.txt', function(err, data){
+        if (err) return handleError(err);
+        handleData(data);
+      });
 
   into:
 
-  ```javascript
-  var fs = require('fs');
+      var fs = require('fs');
 
-  var readFile = RSVP.denodeify(fs.readFile);
+      var readFile = RSVP.denodeify(fs.readFile);
 
-  readFile('myfile.txt').then(handleData, handleError);
-  ```
+      readFile('myfile.txt').then(handleData, handleError);
+
 
   Using `denodeify` makes it easier to compose asynchronous operations instead
   of using callbacks. For example, instead of:
 
-  ```javascript
-  var fs = require('fs');
-  var log = require('some-async-logger');
 
-  fs.readFile('myfile.txt', function(err, data){
-    if (err) return handleError(err);
-    fs.writeFile('myfile2.txt', data, function(err){
-      if (err) throw err;
-      log('success', function(err) {
-        if (err) throw err;
+      var fs = require('fs');
+      var log = require('some-async-logger');
+
+      fs.readFile('myfile.txt', function(err, data){
+        if (err) return handleError(err);
+        fs.writeFile('myfile2.txt', data, function(err){
+          if (err) throw err;
+          log('success', function(err) {
+            if (err) throw err;
+          });
+        });
       });
-    });
-  });
-  ```
 
   You can chain the operations together using `then` from the returned promise:
 
-  ```javascript
-  var fs = require('fs');
-  var denodeify = RSVP.denodeify;
-  var readFile = denodeify(fs.readFile);
-  var writeFile = denodeify(fs.writeFile);
-  var log = denodeify(require('some-async-logger'));
+      var fs = require('fs');
+      var denodeify = RSVP.denodeify;
+      var readFile = denodeify(fs.readFile);
+      var writeFile = denodeify(fs.writeFile);
+      var log = denodeify(require('some-async-logger'));
 
-  readFile('myfile.txt').then(function(data){
-    return writeFile('myfile2.txt', data);
-  }).then(function(){
-    return log('SUCCESS');
-  });
-  .then(function(){
-    // success handler
-  }, function(reason){
-    // rejection handler
-  });
-  ```
+      readFile('myfile.txt').then(function(data){
+        return writeFile('myfile2.txt', data);
+      }).then(function(){
+        return log('SUCCESS');
+      });
+      .then(function(){
+        // success handler
+      }, function(reason){
+        // rejection handler
+      });
 
   @method denodeify
   @for RSVP

--- a/lib/rsvp/race.js
+++ b/lib/rsvp/race.js
@@ -7,26 +7,24 @@ import { isArray } from "./utils";
   `RSVP.race` allows you to watch a series of promises and act as soon as the
   first promise given to the `promises` argument fulfills or rejects.
 
-  For example:
+  Example:
 
-  ```javascript
-  var promise1 = new RSVP.Promise(function(resolve, reject){
-    setTimeout(function(){
-      resolve("promise 1");
-    }, 200);
-  });
+      var promise1 = new RSVP.Promise(function(resolve, reject){
+        setTimeout(function(){
+          resolve("promise 1");
+        }, 200);
+      });
 
-  var promise2 = new RSVP.Promise(function(resolve, reject){
-    setTimeout(function(){
-      resolve("promise 2");
-    }, 100);
-  });
+      var promise2 = new RSVP.Promise(function(resolve, reject){
+        setTimeout(function(){
+          resolve("promise 2");
+        }, 100);
+      });
 
-  RSVP.race([promise1, promise2]).then(function(result){
-    // result === "promise 2" because it was resolved before promise1
-    // was resolved.
-  });
-  ```
+      RSVP.race([promise1, promise2]).then(function(result){
+        // result === "promise 2" because it was resolved before promise1
+        // was resolved.
+      });
 
   `RSVP.race` is deterministic in that only the state of the first completed
   promise matters. For example, even if other promises given to the `promises`
@@ -34,26 +32,24 @@ import { isArray } from "./utils";
   rejected before the other promises became fulfilled, the returned promise
   will become rejected:
 
-  ```javascript
-  var promise1 = new RSVP.Promise(function(resolve, reject){
-    setTimeout(function(){
-      resolve("promise 1");
-    }, 200);
-  });
+      var promise1 = new RSVP.Promise(function(resolve, reject){
+        setTimeout(function(){
+          resolve("promise 1");
+        }, 200);
+      });
 
-  var promise2 = new RSVP.Promise(function(resolve, reject){
-    setTimeout(function(){
-      reject(new Error("promise 2"));
-    }, 100);
-  });
+      var promise2 = new RSVP.Promise(function(resolve, reject){
+        setTimeout(function(){
+          reject(new Error("promise 2"));
+        }, 100);
+      });
 
-  RSVP.race([promise1, promise2]).then(function(result){
-    // Code here never runs because there are rejected promises!
-  }, function(reason){
-    // reason.message === "promise2" because promise 2 became rejected before
-    // promise 1 became fulfilled
-  });
-  ```
+      RSVP.race([promise1, promise2]).then(function(result){
+        // Code here never runs because there are rejected promises!
+      }, function(reason){
+        // reason.message === "promise2" because promise 2 became rejected before
+        // promise 1 became fulfilled
+      });
 
   @method race
   @for RSVP

--- a/lib/rsvp/reject.js
+++ b/lib/rsvp/reject.js
@@ -4,30 +4,25 @@ import { Promise } from "./promise";
   `RSVP.reject` returns a promise that will become rejected with the passed
   `reason`. `RSVP.reject` is essentially shorthand for the following:
 
-  ```javascript
+      var promise = new RSVP.Promise(function(resolve, reject){
+        reject(new Error('WHOOPS'));
+      });
 
-  var promise = new RSVP.Promise(function(resolve, reject){
-    reject(new Error('WHOOPS'));
-  });
-
-  promise.then(function(value){
-    // Code here doesn't run because the promise is rejected!
-  }, function(reason){
-    // reason.message === 'WHOOPS'
-  });
-  ```
+      promise.then(function(value){
+        // Code here doesn't run because the promise is rejected!
+      }, function(reason){
+        // reason.message === 'WHOOPS'
+      });
 
   Instead of writing the above, your code now simply becomes the following:
 
-  ```javascript
-  var promise = RSVP.reject(new Error('WHOOPS'));
+      var promise = RSVP.reject(new Error('WHOOPS'));
 
-  promise.then(function(value){
-    // Code here doesn't run because the promise is rejected!
-  }, function(reason){
-    // reason.message === 'WHOOPS'
-  });
-  ```
+      promise.then(function(value){
+        // Code here doesn't run because the promise is rejected!
+      }, function(reason){
+        // reason.message === 'WHOOPS'
+      });
 
   @method reject
   @for RSVP

--- a/lib/rsvp/resolve.js
+++ b/lib/rsvp/resolve.js
@@ -4,26 +4,21 @@ import { Promise } from "./promise";
   `RSVP.resolve` returns a promise that will become fulfilled with the passed
   `value`. `RSVP.resolve` is essentially shorthand for the following:
 
-  ```javascript
+      var promise = new RSVP.Promise(function(resolve, reject){
+        resolve(1);
+      });
 
-  var promise = new RSVP.Promise(function(resolve, reject){
-    resolve(1);
-  });
-
-  promise.then(function(value){
-    // value === 1
-  });
-  ```
+      promise.then(function(value){
+        // value === 1
+      });
 
   Instead of writing the above, your code now simply becomes the following:
 
-  ```javascript
-  var promise = RSVP.resolve(1);
+      var promise = RSVP.resolve(1);
 
-  promise.then(function(value){
-    // value === 1
-  });
-  ```
+      promise.then(function(value){
+        // value === 1
+      });
 
   @method resolve
   @for RSVP

--- a/lib/rsvp/rethrow.js
+++ b/lib/rsvp/rethrow.js
@@ -12,24 +12,20 @@ var local = (typeof global === "undefined") ? this : global;
   or domain/cause uncaught exception in Node. `rethrow` will throw the error
   again so the error can be handled by the promise.
 
-  ```javascript
+      function throws(){
+        throw new Error('Whoops!');
+      }
 
-  function throws(){
-    throw new Error('Whoops!');
-  }
+      var promise = new RSVP.Promise(function(resolve, reject){
+        throws();
+      });
 
-  var promise = new RSVP.Promise(function(resolve, reject){
-    throws();
-  });
-
-  promise.fail(RSVP.rethrow).then(function(){
-    // Code here doesn't run because the promise became rejected due to an
-    // error!
-  }, function (err){
-    // handle the error here
-  });
-
-  ```
+      promise.fail(RSVP.rethrow).then(function(){
+        // Code here doesn't run because the promise became rejected due to an
+        // error!
+      }, function (err){
+        // handle the error here
+      });
 
   The 'Whoops' error will be thrown on the next turn of the event loop
   and you can watch for it in your console. You can also handle it using a


### PR DESCRIPTION
remove all markdown code syntax for replacement with yuidoc
example indenting (4 spaces)
the markdown syntax was not generating code blocks correctly

defer api docs before change
![rsvp](https://f.cloud.github.com/assets/514063/1698542/2cbac8bc-5f54-11e3-991c-357eecb89359.png)

defer api docs after change
![rsvp](https://f.cloud.github.com/assets/514063/1698540/26d8302e-5f54-11e3-854e-2c428e101309.png)
