### PR TITLE
Twiddle text node to trigger ASAP flush

### DIFF
--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -16,7 +16,7 @@ function useMutationObserver() {
   observer.observe(node, { characterData: true });
 
   return function() {
-    node.data = iterations++;
+    node.data = (iterations = ++iterations % 2);
   };
 }
 


### PR DESCRIPTION
Some buggy `MutationObserver` implementations or polyfills may not trigger a mutation when an attribute is just set again to the same value.

This text node twiddle approach is based on Polymer's [microtask.js](https://github.com/Polymer/platform-dev/blob/master/src/microtask.js).

Fixes #170

Related
- https://github.com/tildeio/rsvp.js/issues/170
- https://github.com/jakearchibald/ES6-Promises/pull/2

/cc @jakearchibald @azakus
