### PR TITLE
Add promise stack trace to instrumentation

### DIFF
--- a/lib/rsvp/instrument.js
+++ b/lib/rsvp/instrument.js
@@ -10,7 +10,8 @@ export default function instrument(eventName, promise, child) {
       detail: promise._detail,
       childGuid: child && promise._guidKey + child._id,
       label: promise._label,
-      timeStamp: now()
+      timeStamp: now(),
+      stack: new Error(promise._label).stack
     });
   } catch(error) {
     setTimeout(function(){


### PR DESCRIPTION
Helps users track promises especially ones that have not been labelled.
/cc @stefanpenner
