### PR TITLE
Add flag to register RSVP.on callbacks

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -27,4 +27,15 @@ function off() {
   config.off.apply(config, arguments);
 }
 
+// Set up instrumentation through `window.__PROMISE_INTRUMENTATION__`
+if (typeof window !== 'undefined' && typeof window.__PROMISE_INSTRUMENTATION__ === 'object') {
+  var callbacks = window.__PROMISE_INSTRUMENTATION__;
+  configure('instrument', true);
+  for (var eventName in callbacks) {
+    if (callbacks.hasOwnProperty(eventName)) {
+      on(eventName, callbacks[eventName]);
+    }
+  }
+}
+
 export { Promise, EventTarget, all, race, hash, rethrow, defer, denodeify, configure, on, off, resolve, reject, async, map, filter };


### PR DESCRIPTION
After brainstorming with @stefanpenner:

``` javascript

window.__PROMISE_INSTRUMENTATION__ = {

  created: function(e) {
    // promise was created
  },
  fulfilled: function(e) {
    // promise was fulfilled
  }
  //...
};
```

This instructs RSVP to set up `RSVP.on` listeners on each of the provided callbacks.  That way we ensure that we don't miss any event.  We can inject the promise assembler later and collect what was triggered.
