### PR TITLE
Documentation tweaks.

### DIFF
--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -23,7 +23,6 @@ var callbacksFor = function(object) {
 export default {
 
   /**
-    @private
     `RSVP.EventTarget.mixin` extends an object with EventTarget methods. For
     Example:
 
@@ -62,6 +61,7 @@ export default {
 
     @method mixin
     @param {Object} object object to extend with EventTarget methods
+    @private
   */
   mixin: function(object) {
     object.on = this.on;
@@ -72,8 +72,6 @@ export default {
   },
 
   /**
-    @private
-
     Registers a callback to be executed when `eventName` is triggered
 
     ```javascript
@@ -87,6 +85,7 @@ export default {
     @method on
     @param {String} eventName name of the event to listen for
     @param {Function} callback function to be called when the event is triggered.
+    @private
   */
   on: function(eventName, callback) {
     var allCallbacks = callbacksFor(this), callbacks;
@@ -103,8 +102,6 @@ export default {
   },
 
   /**
-    @private
-
     You can use `off` to stop firing a particular callback for an event:
 
     ```javascript
@@ -140,6 +137,8 @@ export default {
     given will be removed from the event's callback queue. If no `callback`
     argument is given, all callbacks will be removed from the event's callback
     queue.
+    @private
+
   */
   off: function(eventName, callback) {
     var allCallbacks = callbacksFor(this), callbacks, index;
@@ -157,8 +156,6 @@ export default {
   },
 
   /**
-    @private
-
     Use `trigger` to fire custom events. For example:
 
     ```javascript
@@ -185,6 +182,7 @@ export default {
     @param {String} eventName name of the event to be triggered
     @param {Any} options optional value to be passed to any event handlers for
     the given `eventName`
+    @private
   */
   trigger: function(eventName, options) {
     var allCallbacks = callbacksFor(this),

--- a/lib/rsvp/promise/cast.js
+++ b/lib/rsvp/promise/cast.js
@@ -34,6 +34,7 @@
 
   `RSVP.Promise.cast` is similar to `RSVP.resolve`, but `RSVP.Promise.cast` differs in the
   following ways:
+
   * `RSVP.Promise.cast` serves as a memory-efficient way of getting a promise, when you
   have something that could either be a promise or a value. RSVP.resolve
   will have the same effect but will create a new promise wrapper if the


### PR DESCRIPTION
Fix list in `Promise.cast` documentation.

Before:

![screenshot](https://www.monosnap.com/image/OBr2UV08Mi8KSCAPne3TNA1kU.png)

After:

![screenshot](https://www.monosnap.com/image/NS4P8uTrGECtCbK4zK4f4rmLE.png)

---

YUIDoc will only use documentation found within a code block before any directives. This means that if you start a code block with `@private` none of the documentation text for that method/property will be in the generated output.

Example before:

![screenshot](https://www.monosnap.com/image/RnIb3AFAAcTAaqZoenxZmPGDR.png)

Example after:

![screenshot](https://www.monosnap.com/image/9AuWbnfa3RMJgAGMedbfnLLRN.png)
