### PR TITLE
Fix/cleanup YUIDoc.

### DIFF
--- a/lib/rsvp/all.js
+++ b/lib/rsvp/all.js
@@ -1,5 +1,14 @@
 import Promise from "./promise";
 
+/**
+  This is a convenient alias for `RSVP.Promise.all`.
+
+  @method all
+  @param {Array} array Array of promises.
+  @param {String} label An optional label. This is useful
+  for tooling.
+  @static
+*/
 export default function all(array, label) {
   return Promise.all(array, label);
 };

--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -1,3 +1,9 @@
+/**
+  @method asap
+  @param {Function} callback
+  @param arg
+  @static
+*/
 export default function asap(callback, arg) {
   var length = queue.push([callback, arg]);
   if (length === 1) {

--- a/lib/rsvp/defer.js
+++ b/lib/rsvp/defer.js
@@ -26,9 +26,10 @@ import Promise from "./promise";
    ```
 
   @method defer
-  @for RSVP
-  @param {String} -
+  @param {String} label optional string describing the promise. Useful for
+  tooling.
   @return {Object}
+  @static
  */
 
 export default function defer(label) {

--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -17,8 +17,8 @@ var callbacksFor = function(object) {
 };
 
 /**
-  //@module RSVP
-  //@class EventTarget
+  @class EventTarget
+  @namespace RSVP
 */
 export default {
 

--- a/lib/rsvp/filter.js
+++ b/lib/rsvp/filter.js
@@ -76,13 +76,14 @@ import { isFunction, isArray } from "./utils";
   ```
 
   @method filter
-  @for RSVP
+  @namespace RSVP
   @param {Array} promises
   @param {Function} filterFn - function to be called on each resolved value to
   filter the final results.
   @param {String} label optional string describing the promise. Useful for
   tooling.
   @return {Promise}
+  @static
 */
 function filter(promises, filterFn, label) {
   if (!isArray(promises)) {

--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -80,12 +80,13 @@ import { isNonThenable, keysOf } from './utils';
   ```
 
   @method hash
-  @for RSVP
+  @namespace RSVP
   @param {Object} promises
-  @param {String} label - optional string that describes the promise.
+  @param {String} label optional string that describes the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled when all properties of `promises`
   have been fulfilled, or rejected if any of them become rejected.
+  @static
 */
 export default function hash(object, label) {
   return new Promise(function(resolve, reject){

--- a/lib/rsvp/map.js
+++ b/lib/rsvp/map.js
@@ -70,7 +70,7 @@ import { isArray, isFunction } from "./utils";
   ```
 
   @method map
-  @for RSVP
+  @namespace RSVP
   @param {Array} promises
   @param {Function} mapFn function to be called on each fulfilled promise.
   @param {String} label optional string for labelling the promise.
@@ -78,6 +78,7 @@ import { isArray, isFunction } from "./utils";
   @return {Promise} promise that is fulfilled with the result of calling
   `mapFn` on each fulfilled promise or value when they become fulfilled.
    The promise will be rejected if any of the given `promises` become rejected.
+  @static
 */
 export default function map(promises, mapFn, label) {
 

--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -78,7 +78,7 @@ function makeNodeCallbackFor(resolve, reject) {
   ```
 
   @method denodeify
-  @for RSVP
+  @namespace RSVP
   @param {Function} nodeFunc a "node-style" function that takes a callback as
   its last argument. The callback expects an error to be passed as its first
   argument (if an error occurred, otherwise null), and the value from the
@@ -87,6 +87,7 @@ function makeNodeCallbackFor(resolve, reject) {
   calling the `nodeFunc` function.
   @return {Function} a function that wraps `nodeFunc` to return an
   `RSVP.Promise`
+  @static
 */
 export default function denodeify(nodeFunc, binding) {
   return function()  {

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -14,6 +14,11 @@ var counter = 0;
 function noop() {}
 
 export default Promise;
+
+/**
+  @class Promise
+  @namespace RSVP
+*/
 function Promise(resolver, label) {
   if (!isFunction(resolver)) {
     throw new TypeError('You must pass a resolver function as the first argument to the promise constructor');
@@ -104,6 +109,10 @@ Promise.prototype = {
     config.trigger('error', reason);
   },
 
+  /**
+    @method then
+    @return {Promise} A new promise.
+  */
   then: function(onFulfillment, onRejection, label) {
     var promise = this;
     this._onerror = null;
@@ -126,10 +135,18 @@ Promise.prototype = {
     return thenPromise;
   },
 
+  /**
+    @method catch
+    @return {Promise} A new promise.
+  */
   'catch': function(onRejection, label) {
     return this.then(null, onRejection, label);
   },
 
+  /**
+    @method finally
+    @return {Promise} A new promise.
+  */
   'finally': function(callback, label) {
     var constructor = this.constructor;
 

--- a/lib/rsvp/promise/all.js
+++ b/lib/rsvp/promise/all.js
@@ -1,6 +1,11 @@
 import { isArray, isNonThenable } from "../utils";
 
 /**
+  @class Promise
+  @namespace RSVP
+*/
+
+/**
   Returns a promise that is fulfilled when all the given promises have been
   fulfilled, or rejected if any of them become rejected. The return promise
   is fulfilled with an array that gives all the values in the order they were
@@ -39,11 +44,11 @@ import { isArray, isNonThenable } from "../utils";
   ```
 
   @method all
-  @for RSVP.Promise
   @param {Array} promises
   @param {String} label
   @return {Promise} promise that is fulfilled when all `promises` have been
   fulfilled, or rejected if any of them become rejected.
+  @static
 */
 export default function all(entries, label) {
   if (!isArray(entries)) {

--- a/lib/rsvp/promise/cast.js
+++ b/lib/rsvp/promise/cast.js
@@ -1,4 +1,9 @@
 /**
+  @class Promise
+  @namespace RSVP
+*/
+
+/**
   `RSVP.Promise.cast` returns the same promise if that promise shares a constructor
   with the promise being casted.
 
@@ -44,10 +49,10 @@
   ensured to have the behavior of the constructor you are calling cast on (i.e., RSVP.Promise).
 
   @method cast
-  @for RSVP.Promise
   @param {Object} object to be casted
   @return {Promise} promise that is fulfilled when all properties of `promises`
   have been fulfilled, or rejected if any of them become rejected.
+  @static
 */
 
 export default function cast(object) {

--- a/lib/rsvp/promise/race.js
+++ b/lib/rsvp/promise/race.js
@@ -3,6 +3,11 @@
 import { isArray, isFunction, isNonThenable } from "../utils";
 
 /**
+  @class Promise
+  @namespace RSVP
+*/
+
+/**
   `RSVP.Promise.race` allows you to watch a series of promises and act as soon as the
   first promise given to the `promises` argument fulfills or rejects.
 
@@ -55,7 +60,6 @@ import { isArray, isFunction, isNonThenable } from "../utils";
   ```
 
   @method race
-  @for RSVP.Promise
   @param {Array} promises array of promises to observe
   @param {String} label optional string for describing the promise returned.
   Useful for tooling.
@@ -63,6 +67,7 @@ import { isArray, isFunction, isNonThenable } from "../utils";
   completed promises is resolved with if the first completed promise was
   fulfilled, or rejected with the reason that the first completed promise
   was rejected with.
+  @static
 */
 export default function race(entries, label) {
   if (!isArray(entries)) {

--- a/lib/rsvp/promise/reject.js
+++ b/lib/rsvp/promise/reject.js
@@ -27,12 +27,13 @@
   ```
 
   @method reject
-  @for RSVP.Promise
+  @namespace RSVP
   @param {Any} reason value that the returned promise will be rejected with.
   @param {String} label optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise that will become rejected with the given
   `reason`.
+  @static
 */
 export default function reject(reason, label) {
   /*jshint validthis:true */

--- a/lib/rsvp/promise/resolve.js
+++ b/lib/rsvp/promise/resolve.js
@@ -23,12 +23,12 @@
   ```
 
   @method resolve
-  @for RSVP.Promise
   @param {Any} value value that the returned promise will be resolved with
   @param {String} label optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise that will become fulfilled with the given
   `value`
+  @static
 */
 export default function resolve(value, label) {
   /*jshint validthis:true */

--- a/lib/rsvp/race.js
+++ b/lib/rsvp/race.js
@@ -1,5 +1,10 @@
 import Promise from "./promise";
 
+/**
+  @method race
+  @namespace RSVP
+  @static
+*/
 export default function race(array, label) {
   return Promise.race(array, label);
 };

--- a/lib/rsvp/reject.js
+++ b/lib/rsvp/reject.js
@@ -1,5 +1,11 @@
 import Promise from "./promise";
 
+/**
+  An alias for RSVP.Promise.reject
+  @method reject
+  @namespace RSVP
+  @static
+*/
 export default function reject(reason, label) {
   return Promise.reject(reason, label);
 };

--- a/lib/rsvp/rethrow.js
+++ b/lib/rsvp/rethrow.js
@@ -32,7 +32,6 @@
   rejection handler given to `.then` or `.catch` on the returned promise.
 
   @method rethrow
-  @for RSVP
   @param {Error} reason reason the promise became rejected.
   @throws Error
 */


### PR DESCRIPTION
Sets up main methods with YUIDoc annotations (so that `then`, `catch`, `finally` show up in the docs at least).
