### PR TITLE
Cleanup YUIDocs.

### DIFF
--- a/lib/rsvp/all.js
+++ b/lib/rsvp/all.js
@@ -1,5 +1,15 @@
 import Promise from "./promise";
 
+/**
+  This is a convenient alias for `RSVP.Promise.all`.
+
+  @method all
+  @for RSVP
+  @param {Array} array Array of promises.
+  @param {String} label An optional label. This is useful
+  for tooling.
+  @static
+*/
 export default function all(array, label) {
   return Promise.all(array, label);
 };

--- a/lib/rsvp/all_settled.js
+++ b/lib/rsvp/all_settled.js
@@ -43,13 +43,14 @@ import { isArray, isNonThenable } from "./utils";
   });
   ```
 
-  @method @allSettled
+  @method allSettled
   @for RSVP
-  @param {Array} promises;
+  @param {Array} promises
   @param {String} label - optional string that describes the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled with an array of the settled
   states of the constituent promises.
+  @static
 */
 
 export default function allSettled(entries, label) {

--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -17,8 +17,7 @@ var callbacksFor = function(object) {
 };
 
 /**
-  //@module RSVP
-  //@class EventTarget
+  @class RSVP.EventTarget
 */
 export default {
 

--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -83,10 +83,11 @@ import { isNonThenable, keysOf } from './utils';
   @method hash
   @for RSVP
   @param {Object} promises
-  @param {String} label - optional string that describes the promise.
+  @param {String} label optional string that describes the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled when all properties of `promises`
   have been fulfilled, or rejected if any of them become rejected.
+  @static
 */
 export default function hash(object, label) {
   return new Promise(function(resolve, reject){

--- a/lib/rsvp/map.js
+++ b/lib/rsvp/map.js
@@ -3,7 +3,6 @@ import all from "./all";
 import { isArray, isFunction } from "./utils";
 
 /**
-
  `RSVP.map` is similar to JavaScript's native `map` method, except that it
   waits for all promises to become fulfilled before running the `mapFn` on
   each item in given to `promises`. `RSVP.map` returns a promise that will
@@ -78,6 +77,7 @@ import { isArray, isFunction } from "./utils";
   @return {Promise} promise that is fulfilled with the result of calling
   `mapFn` on each fulfilled promise or value when they become fulfilled.
    The promise will be rejected if any of the given `promises` become rejected.
+  @static
 */
 export default function map(promises, mapFn, label) {
   return all(promises, label).then(function(results){

--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -87,6 +87,7 @@ function makeNodeCallbackFor(resolve, reject) {
   calling the `nodeFunc` function.
   @return {Function} a function that wraps `nodeFunc` to return an
   `RSVP.Promise`
+  @static
 */
 export default function denodeify(nodeFunc, binding) {
   return function()  {

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -17,7 +17,6 @@ export default Promise;
 
 
 /**
-
   Promise objects represent the eventual result of an asynchronous operation. The
   primary way of interacting with a promise is through its `then` method, which
   registers callbacks to receive either a promise’s eventual value or the reason
@@ -116,7 +115,7 @@ export default Promise;
   });
   ```
 
-  @class Promise
+  @class RSVP.Promise
   @param {function}
   @param {String} label optional string for labeling the promise.
   Useful for tooling.
@@ -198,9 +197,6 @@ function publish(promise, settled) {
 }
 
 Promise.prototype = {
-/**
-  @property constructor
-*/
   constructor: Promise,
 
   _id: undefined,
@@ -216,7 +212,6 @@ Promise.prototype = {
   },
 
 /**
-
   The primary way of interacting with a promise is through its `then` method,
   which registers callbacks to receive either a promise's eventual value or the
   reason why the promise cannot be fulfilled.

--- a/lib/rsvp/promise/all.js
+++ b/lib/rsvp/promise/all.js
@@ -1,7 +1,6 @@
 import { isArray, isNonThenable } from "../utils";
 
 /**
-
   `RSVP.Promise.all` accepts an array of promises, and returns a new promise which
   is fulfilled with an array of fulfillment values for the passed promises, or
   rejected with the reason of the first passed promise to be rejected. It casts all
@@ -46,6 +45,7 @@ import { isArray, isNonThenable } from "../utils";
   Useful for tooling.
   @return {Promise} promise that is fulfilled when all `promises` have been
   fulfilled, or rejected if any of them become rejected.
+  @static
 */
 export default function all(entries, label) {
 

--- a/lib/rsvp/promise/cast.js
+++ b/lib/rsvp/promise/cast.js
@@ -1,5 +1,4 @@
 /**
-
   `RSVP.Promise.cast` coerces its argument to a promise, or returns the
   argument if it is already a promise which shares a constructor with the caster.
 
@@ -59,11 +58,11 @@
   ensured to have the behavior of the constructor you are calling cast on (i.e., RSVP.Promise).
 
   @method cast
-  @for RSVP.Promise
   @param {Object} object to be casted
   @param {String} label optional string for labeling the promise.
   Useful for tooling.
   @return {Promise} promise
+  @static
 */
 
 export default function cast(object, label) {

--- a/lib/rsvp/promise/race.js
+++ b/lib/rsvp/promise/race.js
@@ -61,12 +61,12 @@ import { isArray, isFunction, isNonThenable } from "../utils";
   ```
 
   @method race
-  @for RSVP.Promise
   @param {Array} promises array of promises to observe
   @param {String} label optional string for describing the promise returned.
   Useful for tooling.
   @return {Promise} a promise which settles in the same way as the first passed
   promise to settle.
+  @static
 */
 export default function race(entries, label) {
   /*jshint validthis:true */

--- a/lib/rsvp/promise/reject.js
+++ b/lib/rsvp/promise/reject.js
@@ -27,11 +27,11 @@
   ```
 
   @method reject
-  @for RSVP.Promise
   @param {Any} reason value that the returned promise will be rejected with.
   @param {String} label optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise rejected with the given `reason`.
+  @static
 */
 export default function reject(reason, label) {
   /*jshint validthis:true */

--- a/lib/rsvp/promise/resolve.js
+++ b/lib/rsvp/promise/resolve.js
@@ -23,12 +23,12 @@
   ```
 
   @method resolve
-  @for RSVP.Promise
   @param {Any} value value that the returned promise will be resolved with
   @param {String} label optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise that will become fulfilled with the given
   `value`
+  @static
 */
 export default function resolve(value, label) {
   /*jshint validthis:true */

--- a/lib/rsvp/race.js
+++ b/lib/rsvp/race.js
@@ -1,5 +1,14 @@
 import Promise from "./promise";
 
+/**
+  This is a convenient alias for `RSVP.Promise.race`.
+
+  @method race
+  @param {Array} array Array of promises.
+  @param {String} label An optional label. This is useful
+  for tooling.
+  @static
+*/
 export default function race(array, label) {
   return Promise.race(array, label);
 };

--- a/lib/rsvp/reject.js
+++ b/lib/rsvp/reject.js
@@ -1,5 +1,16 @@
 import Promise from "./promise";
 
+/**
+  This is a convenient alias for `RSVP.Promise.reject`.
+
+  @method reject
+  @for RSVP
+  @param {Any} reason value that the returned promise will be rejected with.
+  @param {String} label optional string for identifying the returned promise.
+  Useful for tooling.
+  @return {Promise} a promise rejected with the given `reason`.
+  @static
+*/
 export default function reject(reason, label) {
   return Promise.reject(reason, label);
 };

--- a/lib/rsvp/resolve.js
+++ b/lib/rsvp/resolve.js
@@ -1,5 +1,17 @@
 import Promise from "./promise";
 
+/**
+  This is a convenient alias for `RSVP.Promise.resolve`.
+
+  @method resolve
+  @for RSVP
+  @param {Any} value value that the returned promise will be resolved with
+  @param {String} label optional string for identifying the returned promise.
+  Useful for tooling.
+  @return {Promise} a promise that will become fulfilled with the given
+  `value`
+  @static
+*/
 export default function resolve(value, label) {
   return Promise.resolve(value, label);
 };

--- a/lib/rsvp/rethrow.js
+++ b/lib/rsvp/rethrow.js
@@ -35,6 +35,7 @@
   @for RSVP
   @param {Error} reason reason the promise became rejected.
   @throws Error
+  @static
 */
 export default function rethrow(reason) {
   setTimeout(function() {


### PR DESCRIPTION
After reviewing the updated docs as a module within the Ember docs, I came up with a few tweaks/changes that make things show up much better.

Some screenshots of the integrated docs:

Module listing:

![screenshot](http://take.ms/iTl8m)

`Ember.RSVP` Index:

![screenshot](http://take.ms/p4o8V)

`Ember.RSVP.Promise` Index:

![screenshot](http://take.ms/SzyAC)

`Ember.RSVP.EventTarget` Index:

![screenshot](http://take.ms/xdVgG)

FYI - This took much time to track down: apparently YUIDoc falls down and dies if you have an empty line after an opening comment block (`/**`). If that is the case then all other formatting is thrown off within that block.
