### PR TITLE
Use 'Settle' as label for handling Thenable

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -571,7 +571,7 @@ function handleThenable(promise, value) {
           resolved = true;
 
           reject(promise, val);
-        }, 'derived from: ' + (promise._label || ' unknown promise'));
+        }, 'Settle: ' + (promise._label || ' unknown promise'));
 
         return true;
       }


### PR DESCRIPTION
This made the most sense to me.
This then-promise's purpose is to settle `promise`.
/cc @stefanpenner
