### PR TITLE
Changes to denodeify

### DIFF
--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -2,18 +2,6 @@ import Promise from "./promise";
 
 var slice = Array.prototype.slice;
 
-function makeNodeCallbackFor(resolve, reject) {
-  return function (error, value) {
-    if (error) {
-      reject(error);
-    } else if (arguments.length > 2) {
-      resolve(slice.call(arguments, 1));
-    } else {
-      resolve(value);
-    }
-  };
-}
-
 /**
   `RSVP.denodeify` takes a "node-style" function and returns a function that
   will return an `RSVP.Promise`. You can use `denodeify` in Node.js or the
@@ -33,10 +21,51 @@ function makeNodeCallbackFor(resolve, reject) {
 
   ```javascript
   var fs = require('fs');
-
   var readFile = RSVP.denodeify(fs.readFile);
 
   readFile('myfile.txt').then(handleData, handleError);
+  ```
+
+  If the node function has multiple success parameters, then `denodeify`
+  just returns the first one: 
+  
+  ```javascript
+  var request = RSVP.denodeify(require('request'));
+
+  request('http://example.com').then(function(res) {
+    // ...
+  });
+  ```
+  
+  However, if you need all success parameters, setting `denodeify`'s
+  second parameter to `true` causes it to return all success parameters
+  as an array:
+  
+  ```javascript
+  var request = RSVP.denodeify(require('request'), true);
+
+  request('http://example.com').then(function(result) {
+    // result[0] -> res
+    // result[1] -> body
+  });
+  ```
+
+  Or if you pass it an array with names it returns the parameters as a hash:
+
+  ```javascript
+  var request = RSVP.denodeify(require('request'), ['res', 'body']);
+
+  request('http://example.com').then(function(result) {
+    // result.res
+    // result.body
+  });
+  ```
+
+  Sometimes you need to retain the `this`:
+
+  ```javascript
+  var app = require('express')();
+  var render = RSVP.denodeify(app.render.bind(app));
   ```
 
   Using `denodeify` makes it easier to compose asynchronous operations instead
@@ -44,36 +73,29 @@ function makeNodeCallbackFor(resolve, reject) {
 
   ```javascript
   var fs = require('fs');
-  var log = require('some-async-logger');
 
   fs.readFile('myfile.txt', function(err, data){
-    if (err) return handleError(err);
+    if (err) { ... } // Handle error
     fs.writeFile('myfile2.txt', data, function(err){
-      if (err) throw err;
-      log('success', function(err) {
-        if (err) throw err;
-      });
+      if (err) { ... } // Handle error
+      console.log('done')
     });
   });
   ```
 
-  You can chain the operations together using `then` from the returned promise:
+  you can chain the operations together using `then` from the returned promise:
 
   ```javascript
   var fs = require('fs');
-  var denodeify = RSVP.denodeify;
-  var readFile = denodeify(fs.readFile);
-  var writeFile = denodeify(fs.writeFile);
-  var log = denodeify(require('some-async-logger'));
+  var readFile = RSVP.denodeify(fs.readFile);
+  var writeFile = RSVP.denodeify(fs.writeFile);
 
   readFile('myfile.txt').then(function(data){
     return writeFile('myfile2.txt', data);
   }).then(function(){
-    return log('SUCCESS');
-  }).then(function(){
-    // success handler
-  }, function(reason){
-    // rejection handler
+    console.log('done')
+  }).catch(function(error){
+    // Handle error
   });
   ```
 
@@ -84,21 +106,53 @@ function makeNodeCallbackFor(resolve, reject) {
   its last argument. The callback expects an error to be passed as its first
   argument (if an error occurred, otherwise null), and the value from the
   operation as its second argument ("function(err, value){ }").
-  @param {Any} binding optional argument for binding the "this" value when
-  calling the `nodeFunc` function.
+  @param {Boolean|Array} successArgumentNames An optional paramter that if set
+  to `true` causes the promise to fulfill with the callback's success arguments
+  as an array. This is useful if the node function has multiple success
+  paramters. If you set this paramter to an array with names, the promise will
+  fulfill with a hash with these names as keys and the success parameters as
+  values.
   @return {Function} a function that wraps `nodeFunc` to return an
   `RSVP.Promise`
   @static
 */
-export default function denodeify(nodeFunc, binding) {
+export default function denodeify(nodeFunc, successArgumentNames) {
   return function()  {
-    var nodeArgs = slice.call(arguments), resolve, reject;
-    var thisArg = this || binding;
+    var nodeArgs = slice.call(arguments);
+    var successValuesAsArray = successArgumentNames === true;
+    var successValuesAsHash = Array.isArray(successArgumentNames);
+    var thisArg = this;
+
+    if (!successValuesAsArray && !successValuesAsHash && successArgumentNames) {
+      console.warn('Deprecation: RSVP.denodeify() doesn\'t allow setting the '
+        + '"this" binding anymore. Use yourFunction.bind(yourThis) instead.');
+      thisArg = successArgumentNames;
+    }
 
     return new Promise(function(resolve, reject) {
       Promise.all(nodeArgs).then(function(nodeArgs) {
         try {
-          nodeArgs.push(makeNodeCallbackFor(resolve, reject));
+
+          var callback = function (error, value) {
+            if (error) {
+              reject(error);
+            } else if (successValuesAsArray) {
+              resolve(slice.call(arguments, 1));
+            } else if (successValuesAsHash) {
+              var hash = {};
+              var successArguments = slice.call(arguments, 1);
+
+              successArgumentNames.forEach(function(name, index) {
+                hash[name] = successArguments[index];
+              });
+
+              resolve(hash);
+            } else {
+              resolve(value);
+            }
+          };
+
+          nodeArgs.push(callback);
           nodeFunc.apply(thisArg, nodeArgs);
         } catch(e) {
           reject(e);

--- a/test/tests/extension_test.js
+++ b/test/tests/extension_test.js
@@ -402,15 +402,43 @@ describe("RSVP extensions", function() {
       });
     });
 
-    specify('fulfilled with array if node function calls back with multiple arguments', function(done) {
+    specify('fulfilled with array if if user called RSVP.denodeify(nodeFunc, true)', function(done) {
       function nodeFunc(cb) {
         cb(null, 1, 2, 3);
+      }
+
+      var denodeifiedFunc = RSVP.denodeify(nodeFunc, true);
+
+      denodeifiedFunc().then(function(value) {
+        assert(objectEquals(value, [1, 2, 3]));
+        done();
+      });
+    });
+
+    specify('fulfilled with hash if if user called RSVP.denodeify with an array as second argument', function(done) {
+      function nodeFunc(cb) {
+        cb(null, 1, 2, 3);
+      }
+
+      var denodeifiedFunc = RSVP.denodeify(nodeFunc, ['a', 'b', 'c']);
+
+      denodeifiedFunc().then(function(value) {
+        assert.equal(value.a, '1');
+        assert.equal(value.b, '2');
+        assert.equal(value.c, '3');
+        done();
+      });
+    });
+
+    specify('fulfilled with just the first value if node function returns an array', function(done) {
+      function nodeFunc(cb) {
+        cb(null, 42, 2, 3);
       }
 
       var denodeifiedFunc = RSVP.denodeify(nodeFunc);
 
       denodeifiedFunc().then(function(value) {
-        assert(objectEquals(value, [1, 2, 3]));
+        assert.equal(value, 42);
         done();
       });
     });


### PR DESCRIPTION
Changes:
- `denodeify()`'s second parameter isn't a binding for `this` anymore.
- If the callback of the node function has more than one success paramter it now returns just the first (instead of an array) Fixes #198 (The problem with the old behavior was that 3rd party module authors might change the number of success parameters of the callback at any time and consider it a non-breaking change. And it would be non-breaking if the user didn't use `denodify`)
- If the user sets the second parameter to `true` the promise  fulfills to **always** an array with the success parameters of the callback as values.
- If the user sets the second parameter to an array with names, the promise fulfills to a hash with the names as keys and the success parameters as values
- If the user supplies a second parameter that is neither an array or `true` it emulates the old behaviour and uses it as `this` binding. The user gets a deprecation warning that says that he/she should use .bind() instead.

Also updated the tests to test for this new behaviour.
