### PR TITLE
Update deferred docs to not use `new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ a promise, whilst providing late access to the `resolve()` and `reject()` method
 A deferred object has this form: `{ promise, resolve(x), reject(r) }`.
 
 ```javascript
-var deferred = new RSVP.defer();
+var deferred = RSVP.defer();
 // ...
 deferred.promise // access the promise
 // ...


### PR DESCRIPTION
Based on this PR: https://github.com/emberjs/ember.js/pull/2571 we don't need to call RSVP.defer() with new. This section of the readme is confusing because it clashes with the Ember docs' defer example: http://emberjs.com/api/classes/Ember.RSVP.html#method_defer
