### PR TITLE
Remove load-grunt-tasks dependency and requirement

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-  require('load-grunt-tasks')(grunt);
   var config = require('load-grunt-config')(grunt, {
     configPath: 'tasks/options',
     init: false

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "grunt-s3": "~0.2.0-alpha.2",
     "jshint": "~0.9",
     "load-grunt-config": "~0.5.0",
-    "load-grunt-tasks": "~0.2.0",
     "mocha-phantomjs": "~3.1.6",
     "promises-aplus-tests": "git://github.com/stefanpenner/promises-tests.git",
     "connect-redirection": "0.0.1",


### PR DESCRIPTION
`load-grunt-config` requires by default `load-grunt-tasks`, this double require
leads to a `TypeError: Object #<Object> has no method 'init'` when trying
to require the `s3` task for the second time.

See also https://github.com/pifantastic/grunt-s3/issues/68
