### PR TITLE
Inheritance for denodeify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Master
 
+* Changes to RSVP.denodeify: Behaviour for multiple success callback parameters
+  has been improved and the denodefied function now inherits from the original
+  node function.
+
 # 3.0.2
 
 * [Spec compliance] Promise.all and Promise.race should reject, not throw on invalid input
@@ -88,7 +92,7 @@
 * correctly test and fix self fulfillment
 * remove promise coercion.
 * Fix infinite recursion with deep self fulfilling promises
-* doc fixes 
+* doc fixes
 
 # 2.0.0
 

--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -67,6 +67,20 @@ import { isArray } from "./utils";
   var render = RSVP.denodeify(app.render.bind(app));
   ```
 
+  The denodified function inherits from the original function. It works in all
+  environments, except IE 10 and below. Consequently all properties of the original
+  function are available to you. However, any properties you change on the
+  denodeified function won't be changed on the original function. Example:
+
+  ```javascript
+  var request = RSVP.denodeify(require('request')),
+      cookieJar = request.jar(); // <- Inheritance is used here
+
+  request('http://example.com', {jar: cookieJar}).then(function(res) {
+    // cookieJar.cookies holds now the cookies returned by example.com
+  });
+  ```
+
   Using `denodeify` makes it easier to compose asynchronous operations instead
   of using callbacks. For example, instead of:
 
@@ -105,7 +119,7 @@ import { isArray } from "./utils";
   its last argument. The callback expects an error to be passed as its first
   argument (if an error occurred, otherwise null), and the value from the
   operation as its second argument ("function(err, value){ }").
-  @param {Boolean|Array} successArgumentNames An optional paramter that if set
+  @param {Boolean|Array} argumentNames An optional paramter that if set
   to `true` causes the promise to fulfill with the callback's success arguments
   as an array. This is useful if the node function has multiple success
   paramters. If you set this paramter to an array with names, the promise will
@@ -116,12 +130,13 @@ import { isArray } from "./utils";
   @static
 */
 export default function denodeify(nodeFunc, argumentNames) {
-  return function()  {
+  var asArray = argumentNames === true;
+  var asHash = isArray(argumentNames);
+
+  function denodeifiedFunction() {
     /* global nodeArgs, $a_slice */
     $a_slice(nodeArgs, arguments);
 
-    var asArray = argumentNames === true;
-    var asHash = isArray(argumentNames);
     var thisArg;
 
     if (!asArray && !asHash && argumentNames) {
@@ -171,4 +186,8 @@ export default function denodeify(nodeFunc, argumentNames) {
       }
     });
   };
-}
+
+  denodeifiedFunction.__proto__ = nodeFunc;
+
+  return denodeifiedFunction;
+};

--- a/test/tests/extension_test.js
+++ b/test/tests/extension_test.js
@@ -474,6 +474,22 @@ describe("RSVP extensions", function() {
         done();
       });
     });
+    
+    specify('should inherit from node function', function() {
+      function nodeFunc(cb) { cb('hello'); }
+      nodeFunc.something = 'test123'
+
+      var denodeifiedFunc = RSVP.denodeify(nodeFunc);
+
+      assert.equal(denodeifiedFunc.something, 'test123');
+      
+      denodeifiedFunc().then(function(result) {
+        assert.equal(result, 'hello');
+        assert.equal(denodeifiedFunc.something, 'test123');
+      }, function() {
+        assert.equal(false);
+      });
+    });
 
     specify('integration test showing how awesome this can be', function(done) {
       function readFile(fileName, cb) {


### PR DESCRIPTION
Set the `__proto__` on the denodeified function so that it inherits from the original function. I added a practical example why this is useful.
