### PR TITLE
Add a param name to make yuidoc happy

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -118,7 +118,7 @@ export default Promise;
   ```
 
   @class RSVP.Promise
-  @param {function}
+  @param {function} resolver
   @param {String} label optional string for labeling the promise.
   Useful for tooling.
   @constructor


### PR DESCRIPTION
This fixes a yuidoc warning but doesn't seem to have any other particle benefits.
