### PR TITLE
More opts

### DIFF
--- a/lib/rsvp/-internal.js
+++ b/lib/rsvp/-internal.js
@@ -1,0 +1,246 @@
+import {
+  objectOrFunction,
+  isFunction,
+  now
+} from './utils';
+
+import instrument from './instrument';
+
+import { config } from "./config";
+
+function noop() {}
+
+var PENDING   = void 0;
+var SEALED    = 0;
+var FULFILLED = 1;
+var REJECTED  = 2;
+
+var GET_THEN_ERROR = new ErrorObject();
+
+function getThen(promise) {
+  try {
+    return promise.then;
+  } catch(error) {
+    GET_THEN_ERROR.error = error;
+    return GET_THEN_ERROR;
+  }
+}
+
+function tryThen(then, value, fulfillmentHandler, rejectionHandler) {
+  try {
+    then.call(value, fulfillmentHandler, rejectionHandler);
+  } catch(e) {
+    return e;
+  }
+}
+
+function handleThenable(promise, maybeThenable) {
+  var sealed = false;
+  var then = getThen(maybeThenable);
+
+  if (then === GET_THEN_ERROR) {
+    reject(promise, GET_THEN_ERROR.error);
+  } else if (then === undefined) {
+    fulfill(promise, maybeThenable);
+  } else if (isFunction(then)) {
+    var error = tryThen(then, maybeThenable, function(value) {
+      if (sealed) { return; }
+      sealed = true;
+
+      if (maybeThenable !== value) {
+        resolve(promise, value);
+      } else {
+        fulfill(promise, value);
+      }
+    }, function(reason) {
+      if (sealed) { return; }
+      sealed = true;
+
+      reject(promise, reason);
+    }, 'Settle: ' + (promise._label || ' unknown promise'));
+
+    if (!sealed && error) {
+      sealed = true;
+      reject(promise, error);
+    }
+  } else {
+    fulfill(promise, maybeThenable);
+  }
+}
+
+function resolve(promise, value) {
+  if (promise === value) {
+    fulfill(promise, value);
+  } else if (objectOrFunction(value)) {
+    handleThenable(promise, value);
+  } else {
+    fulfill(promise, value);
+  }
+}
+
+function publishFulfillment(promise) {
+  publish(promise, promise._state = FULFILLED);
+}
+
+function publishRejection(promise) {
+  if (promise._onerror) {
+    promise._onerror(promise._result);
+  }
+
+  publish(promise, promise._state = REJECTED);
+}
+
+function fulfill(promise, value) {
+  if (promise._state !== PENDING) { return; }
+
+  promise._result = value;
+
+  if (promise._subscribers.length === 0) {
+    promise._state = FULFILLED;
+    if (config.instrument) {
+      instrument('fulfilled', promise);
+    }
+  } else {
+    promise._state = SEALED;
+    config.async(publishFulfillment, promise);
+  }
+}
+
+function reject(promise, reason) {
+  if (promise._state !== PENDING) { return; }
+
+  promise._result = reason;
+  promise._state = SEALED;
+
+  config.async(publishRejection, promise);
+}
+
+function subscribe(parent, child, onFulfillment, onRejection) {
+  var subscribers = parent._subscribers;
+  var length = subscribers.length;
+
+  subscribers[length] = child;
+  subscribers[length + FULFILLED] = onFulfillment;
+  subscribers[length + REJECTED]  = onRejection;
+
+  if (length === 0 && parent._state) {
+    config.async(parent._state === FULFILLED ? publishFulfillment : publishRejection, parent);
+  }
+}
+
+function publish(promise, settled) {
+  var subscribers = promise._subscribers;
+
+  if (config.instrument) {
+    instrument(settled === FULFILLED ? 'fulfilled' : 'rejected', promise);
+  }
+
+  if (subscribers.length === 0) { return; }
+
+  var child, callback, detail = promise._result;
+
+  for (var i = 0; i < subscribers.length; i += 3) {
+    child = subscribers[i];
+    callback = subscribers[i + settled];
+
+    if (child) {
+      invokeCallback(settled, child, callback, detail);
+    } else {
+      callback(detail);
+    }
+  }
+
+  promise._subscribers.length = 0;
+}
+
+function subscribe(parent, child, onFulfillment, onRejection) {
+  var subscribers = parent._subscribers;
+  var length = subscribers.length;
+
+  subscribers[length] = child;
+  subscribers[length + FULFILLED] = onFulfillment;
+  subscribers[length + REJECTED]  = onRejection;
+
+  if (length === 0 && parent._state) {
+    config.async(parent._state === FULFILLED ? publishFulfillment : publishRejection, parent);
+  }
+}
+
+function ErrorObject() {
+  this.error = null;
+}
+
+var TRY_CATCH_ERROR = new ErrorObject();
+
+function tryCatch(callback, detail) {
+  try {
+    return callback(detail);
+  } catch(e) {
+    TRY_CATCH_ERROR.error = e;
+    return TRY_CATCH_ERROR;
+  }
+}
+
+function invokeCallback(settled, promise, callback, detail) {
+  var hasCallback = isFunction(callback),
+      value, error, succeeded, failed;
+
+  if (hasCallback) {
+    value = tryCatch(callback, detail);
+
+    if (value === TRY_CATCH_ERROR) {
+      failed = true;
+      error = value.error;
+      value = null;
+    } else {
+      succeeded = true;
+    }
+
+    if (promise === value) {
+      reject(promise, new TypeError('A promises callback cannot return that same promise.'));
+      return;
+    }
+
+  } else {
+    value = detail;
+    succeeded = true;
+  }
+
+  if (hasCallback && succeeded) {
+    resolve(promise, value);
+  } else if (failed) {
+    reject(promise, error);
+  } else if (settled === FULFILLED) {
+    resolve(promise, value);
+  } else if (settled === REJECTED) {
+    reject(promise, value);
+  }
+}
+
+function initializePromise(promise, resolver) {
+  function resolvePromise(value) {
+    resolve(promise, value);
+  }
+
+  function rejectPromise(reason) {
+    reject(promise, reason);
+  }
+
+  try {
+    resolver(resolvePromise, rejectPromise);
+  } catch(e) {
+    rejectPromise(e);
+  }
+}
+
+export {
+  noop,
+  resolve,
+  reject,
+  fulfill,
+  subscribe,
+  publish,
+  publishFulfillment,
+  publishRejection,
+  initializePromise
+};

--- a/lib/rsvp/instrument.js
+++ b/lib/rsvp/instrument.js
@@ -7,7 +7,7 @@ export default function instrument(eventName, promise, child) {
     config.trigger(eventName, {
       guid: promise._guidKey + promise._id,
       eventName: eventName,
-      detail: promise._detail,
+      detail: promise._result,
       childGuid: child && promise._guidKey + child._id,
       label: promise._label,
       timeStamp: now(),

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -1,11 +1,22 @@
 import { config } from "./config";
 import EventTarget from "./events";
 import instrument from './instrument';
+
 import {
   objectOrFunction,
   isFunction,
   now
 } from './utils';
+
+import {
+  noop,
+  resolve,
+  reject,
+  fulfill,
+  subscribe,
+  initializePromise
+} from './-internal';
+
 import cast from './promise/cast';
 import all from './promise/all';
 import race from './promise/race';
@@ -15,10 +26,7 @@ import Reject from './promise/reject';
 var guidKey = 'rsvp_' + now() + '-';
 var counter = 0;
 
-function noop() {}
-
 export default Promise;
-
 /**
   Promise objects represent the eventual result of an asynchronous operation. The
   primary way of interacting with a promise is through its `then` method, which
@@ -145,62 +153,11 @@ function Promise(resolver, label) {
   }
 }
 
-function initializePromise(promise, resolver) {
-  function resolvePromise(value) {
-    resolve(promise, value);
-  }
-
-  function rejectPromise(reason) {
-    reject(promise, reason);
-  }
-
-  try {
-    resolver(resolvePromise, rejectPromise);
-  } catch(e) {
-    rejectPromise(e);
-  }
-}
-
 Promise.cast = cast;
 Promise.all = all;
 Promise.race = race;
 Promise.resolve = Resolve;
 Promise.reject = Reject;
-
-var PENDING   = void 0;
-var SEALED    = 0;
-var FULFILLED = 1;
-var REJECTED  = 2;
-
-function subscribe(parent, child, onFulfillment, onRejection) {
-  var subscribers = parent._subscribers;
-  var length = subscribers.length;
-
-  subscribers[length] = child;
-  subscribers[length + FULFILLED] = onFulfillment;
-  subscribers[length + REJECTED]  = onRejection;
-
-  if (length === 0 && parent._state) {
-    config.async(parent._state === FULFILLED ? publishFulfillment : publishRejection, parent);
-  }
-}
-
-function publish(promise, settled) {
-  var child, callback, subscribers = promise._subscribers, detail = promise._result;
-
-  if (config.instrument) {
-    instrument(settled === FULFILLED ? 'fulfilled' : 'rejected', promise);
-  }
-
-  for (var i = 0; i < subscribers.length; i += 3) {
-    child = subscribers[i];
-    callback = subscribers[i + settled];
-
-    invokeCallback(settled, child, callback, detail);
-  }
-
-  promise._subscribers.length = 0;
-}
 
 Promise.prototype = {
   constructor: Promise,
@@ -512,110 +469,3 @@ Promise.prototype = {
     }, label);
   }
 };
-
-function invokeCallback(settled, promise, callback, detail) {
-  var hasCallback = isFunction(callback),
-      value, error, succeeded, failed;
-
-  if (hasCallback) {
-    try {
-      value = callback(detail);
-      succeeded = true;
-    } catch(e) {
-      failed = true;
-      error = e;
-    }
-  } else {
-    value = detail;
-    succeeded = true;
-  }
-
-  if (handleThenable(promise, value)) {
-    return;
-  } else if (hasCallback && succeeded) {
-    resolve(promise, value);
-  } else if (failed) {
-    reject(promise, error);
-  } else if (settled === FULFILLED) {
-    resolve(promise, value);
-  } else if (settled === REJECTED) {
-    reject(promise, value);
-  }
-}
-
-function handleThenable(promise, value) {
-  var then = null,
-  resolved;
-
-  try {
-    if (promise === value) {
-      throw new TypeError("A promises callback cannot return that same promise.");
-    }
-
-    if (objectOrFunction(value)) {
-      then = value.then;
-
-      if (isFunction(then)) {
-        then.call(value, function(val) {
-          if (resolved) { return true; }
-          resolved = true;
-
-          if (value !== val) {
-            resolve(promise, val);
-          } else {
-            fulfill(promise, val);
-          }
-        }, function(val) {
-          if (resolved) { return true; }
-          resolved = true;
-
-          reject(promise, val);
-        }, 'Settle: ' + (promise._label || ' unknown promise'));
-
-        return true;
-      }
-    }
-  } catch (error) {
-    if (resolved) { return true; }
-    reject(promise, error);
-    return true;
-  }
-
-  return false;
-}
-
-function resolve(promise, value) {
-  if (promise === value) {
-    fulfill(promise, value);
-  } else if (!handleThenable(promise, value)) {
-    fulfill(promise, value);
-  }
-}
-
-function fulfill(promise, value) {
-  if (promise._state !== PENDING) { return; }
-  promise._state = SEALED;
-  promise._result = value;
-
-  config.async(publishFulfillment, promise);
-}
-
-function reject(promise, reason) {
-  if (promise._state !== PENDING) { return; }
-  promise._state = SEALED;
-  promise._result = reason;
-
-  config.async(publishRejection, promise);
-}
-
-function publishFulfillment(promise) {
-  publish(promise, promise._state = FULFILLED);
-}
-
-function publishRejection(promise) {
-  if (promise._onerror) {
-    promise._onerror(promise._result);
-  }
-
-  publish(promise, promise._state = REJECTED);
-}

--- a/lib/rsvp/promise/all.js
+++ b/lib/rsvp/promise/all.js
@@ -3,6 +3,13 @@ import {
   isMaybeThenable
 } from "../utils";
 
+import {
+  noop,
+  reject,
+  fulfill,
+  subscribe
+} from '../-internal';
+
 /**
   `RSVP.Promise.all` accepts an array of promises, and returns a new promise which
   is fulfilled with an array of fulfillment values for the passed promises, or
@@ -51,48 +58,52 @@ import {
   @static
 */
 export default function all(entries, label) {
-
   /*jshint validthis:true */
   var Constructor = this;
 
-  return new Constructor(function(resolve, reject) {
-    if (!isArray(entries)) {
-      throw new TypeError('You must pass an array to all.');
-    }
+  var promise = new Constructor(noop, label);
 
-    var remaining = entries.length;
-    var results = new Array(remaining);
-    var entry, pending = true;
+   if (!isArray(entries)) {
+    reject(promise, new TypeError('You must pass an array to all.'));
+    return promise;
+  }
 
-    if (remaining === 0) {
-      resolve(results);
-      return;
-    }
+  var remaining = entries.length;
+  var results = new Array(remaining);
+  var entry, pending = true;
 
-    function fulfillmentAt(index) {
-      return function(value) {
-        results[index] = value;
-        if (--remaining === 0) {
-          resolve(results);
-        }
-      };
-    }
+  if (remaining === 0) {
+    fulfill(promise, results);
+    return promise;
+  }
 
-    function onRejection(reason) {
-      remaining = 0;
-      reject(reason);
-    }
-
-    for (var index = 0; index < entries.length; index++) {
-      entry = entries[index];
-      if (isMaybeThenable(entry)) {
-        Constructor.resolve(entry).then(fulfillmentAt(index), onRejection);
-      } else {
-        results[index] = entry;
-        if (--remaining === 0) {
-          resolve(results);
-        }
+  for (var index = 0; index < entries.length; index++) {
+    entry = entries[index];
+    if (isMaybeThenable(entry)) {
+      subscribe(Constructor.resolve(entry), undefined, fulfillmentAt(index, results, promise), onRejection);
+    } else {
+      results[index] = entry;
+      if (--remaining === 0) {
+        fulfill(promise, results);
       }
     }
-  }, label);
-};
+  }
+
+  return promise;
+
+  function onRejection(reason) {
+    remaining = 0;
+    reject(promise, reason);
+  }
+
+  function fulfillmentAt(index, results, promise) {
+    return function(value) {
+      results[index] = value;
+      if (--remaining === 0) {
+        fulfill(promise, results);
+      }
+    };
+  }
+}
+
+

--- a/lib/rsvp/promise/cast.js
+++ b/lib/rsvp/promise/cast.js
@@ -1,3 +1,5 @@
+import resolve from './resolve';
+
 /**
   @deprecated
 
@@ -66,15 +68,4 @@
   Useful for tooling.
   @return {Promise} promise
 */
-export default function cast(object, label) {
-  /*jshint validthis:true */
-  var Constructor = this;
-
-  if (object && typeof object === 'object' && object.constructor === Constructor) {
-    return object;
-  }
-
-  return new Constructor(function(resolve) {
-    resolve(object);
-  }, label);
-};
+export default resolve;

--- a/lib/rsvp/promise/race.js
+++ b/lib/rsvp/promise/race.js
@@ -1,10 +1,14 @@
-/* global toString */
-
 import {
   isArray,
   isFunction,
   isMaybeThenable
 } from "../utils";
+
+import {
+  noop,
+  resolve,
+  reject
+} from '../-internal';
 
 /**
   `RSVP.Promise.race` returns a new promise which is settled in the same way as the
@@ -76,25 +80,28 @@ export default function race(entries, label) {
   /*jshint validthis:true */
   var Constructor = this, entry;
 
-  return new Constructor(function(resolve, reject) {
-    if (!isArray(entries)) {
-      throw new TypeError('You must pass an array to race.');
+  var promise = new Constructor(noop, label);
+
+  if (!isArray(entries)) {
+    reject(promise, new TypeError('You must pass an array to race.'));
+    return promise;
+  }
+
+  var pending = true;
+
+  function onFulfillment(value) { if (pending) { pending = false; resolve(promise, value); } }
+  function onRejection(reason)  { if (pending) { pending = false; reject(promise, reason); } }
+
+  for (var i = 0; pending && i < entries.length; i++) {
+    entry = entries[i];
+    if (isMaybeThenable(entry)) {
+      Constructor.resolve(entry).then(onFulfillment, onRejection);
+    } else {
+      pending = false;
+      resolve(promise, entry);
+      return promise;
     }
+  }
 
-    var pending = true;
-
-    function onFulfillment(value) { if (pending) { pending = false; resolve(value); } }
-    function onRejection(reason)  { if (pending) { pending = false; reject(reason); } }
-
-    for (var i = 0; i < entries.length; i++) {
-      entry = entries[i];
-      if (isMaybeThenable(entry)) {
-        Constructor.resolve(entry).then(onFulfillment, onRejection);
-      } else {
-        pending = false;
-        resolve(entry);
-        return;
-      }
-    }
-  }, label);
-};
+  return promise;
+}

--- a/lib/rsvp/promise/reject.js
+++ b/lib/rsvp/promise/reject.js
@@ -1,3 +1,8 @@
+import {
+  noop,
+  reject as _reject
+} from '../-internal';
+
 /**
   `RSVP.Promise.reject` returns a promise rejected with the passed `reason`.
   It is shorthand for the following:
@@ -36,8 +41,7 @@
 export default function reject(reason, label) {
   /*jshint validthis:true */
   var Constructor = this;
-
-  return new Constructor(function (resolve, reject) {
-    reject(reason);
-  }, label);
-};
+  var promise = new Constructor(noop, label);
+  _reject(promise, reason);
+  return promise;
+}

--- a/lib/rsvp/promise/resolve.js
+++ b/lib/rsvp/promise/resolve.js
@@ -1,3 +1,8 @@
+import {
+  noop,
+  resolve as _resolve
+} from '../-internal';
+
 /**
   `RSVP.Promise.resolve` returns a promise that will become resolved with the
   passed `value`. It is shorthand for the following:
@@ -38,7 +43,7 @@ export default function resolve(object, label) {
     return object;
   }
 
-  return new Constructor(function(resolve) {
-    resolve(object);
-  }, label);
-};
+  var promise = new Constructor(noop, label);
+  _resolve(promise, object);
+  return promise;
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rsvp",
   "namespace": "RSVP",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "A lightweight library that provides tools for organizing asynchronous code",
   "main": "dist/commonjs/main.js",
   "directories": {


### PR DESCRIPTION
more perf & refactoring
- reduce closures
- isolate necessary de-optimizations to small functions
- reduce overhead of internals usage by adding the ability for
  _internals_ to subscribe to other promises without the expense of
  `then`
- fulfillment with no subscribers need not attempt to queue and
  broadcast to subscribers. The Act of subscribing queues, schedules and
  flushes the micro task queue.

Still lots more low hanging fruit just need to find time. 

MicroBenchmarks:

37.0.1991.0 canary
platform == build in promises

``` sh
Running Benchmark Suite for test - All 1 ...
- [All 1] platform x 67,082 ops/sec ±3.62% (55 runs sampled)
- [All 1] rsvp-2.0.4 x 21,294 ops/sec ±13.03% (45 runs sampled)
- [All 1] rsvp-3.0.0 x 228,572 ops/sec ±10.84% (45 runs sampled)
- [All 1] rsvp-3.0.6 x 311,091 ops/sec ±9.73% (51 runs sampled)
- [All 1] rsvp x 369,172 ops/sec ±4.57% (43 runs sampled)

Running Benchmark Suite for test - All 2 ...
- [All 2] platform x 31,086 ops/sec ±5.71% (48 runs sampled)
- [All 2] rsvp-2.0.4 x 10,354 ops/sec ±10.83% (50 runs sampled)
- [All 2] rsvp-3.0.0 x 104,334 ops/sec ±6.45% (52 runs sampled)
- [All 2] rsvp-3.0.6 x 171,428 ops/sec ±7.14% (50 runs sampled)
- [All 2] rsvp x 316,104 ops/sec ±6.37% (54 runs sampled)

Running Benchmark Suite for test - All 10 ...
- [All 10] platform x 8,659 ops/sec ±5.19% (53 runs sampled)
- [All 10] rsvp-2.0.4 x 20,915 ops/sec ±9.44% (39 runs sampled)
- [All 10] rsvp-3.0.0 x 227,771 ops/sec ±7.86% (48 runs sampled)
- [All 10] rsvp-3.0.6 x 270,765 ops/sec ±11.72% (45 runs sampled)
- [All 10] rsvp x 443,783 ops/sec ±5.28% (48 runs sampled)

Running Benchmark Suite for test - All 100 ...
- [All 100] platform x 1,244 ops/sec ±5.07% (51 runs sampled)
- [All 100] rsvp-2.0.4 x 17,959 ops/sec ±9.60% (42 runs sampled)
- [All 100] rsvp-3.0.0 x 130,297 ops/sec ±16.25% (50 runs sampled)
- [All 100] rsvp-3.0.6 x 153,073 ops/sec ±7.61% (49 runs sampled)
- [All 100] rsvp x 284,933 ops/sec ±5.75% (50 runs sampled)

Running Benchmark Suite for test - All 1000 ...
- [All 1000] platform x 125 ops/sec ±5.12% (52 runs sampled)
- [All 1000] rsvp-2.0.4 x 6,519 ops/sec ±30.33% (40 runs sampled)
- [All 1000] rsvp-3.0.0 x 31,419 ops/sec ±6.42% (47 runs sampled)
- [All 1000] rsvp-3.0.6 x 23,182 ops/sec ±5.27% (46 runs sampled)
- [All 1000] rsvp x 41,246 ops/sec ±8.50% (41 runs sampled)

Running Benchmark Suite for test - All 10000 ...
- [All 10000] platform x 6.21 ops/sec ±8.65% (33 runs sampled)
- [All 10000] rsvp-2.0.4 x 1,603 ops/sec ±15.25% (50 runs sampled)
- [All 10000] rsvp-3.0.0 x 2,783 ops/sec ±6.36% (39 runs sampled)
- [All 10000] rsvp-3.0.6 x 2,691 ops/sec ±7.93% (52 runs sampled)
- [All 10000] rsvp x 4,873 ops/sec ±9.37% (50 runs sampled)

Running Benchmark Suite for test - All object 1 ...
- [All object 1] platform x 62,204 ops/sec ±6.82% (51 runs sampled)
- [All object 1] rsvp-2.0.4 x 18,818 ops/sec ±9.99% (37 runs sampled)
- [All object 1] rsvp-3.0.0 x 159,462 ops/sec ±5.40% (50 runs sampled)
- [All object 1] rsvp-3.0.6 x 138,120 ops/sec ±6.56% (39 runs sampled)
- [All object 1] rsvp x 286,668 ops/sec ±6.25% (50 runs sampled)

Running Benchmark Suite for test - All object 2 ...
- [All object 2] platform x 43,205 ops/sec ±3.27% (55 runs sampled)
- [All object 2] rsvp-2.0.4 x 23,508 ops/sec ±19.92% (22 runs sampled)
- [All object 2] rsvp-3.0.0 x 115,721 ops/sec ±6.85% (47 runs sampled)
- [All object 2] rsvp-3.0.6 x 145,395 ops/sec ±4.59% (49 runs sampled)
- [All object 2] rsvp x 192,970 ops/sec ±8.53% (30 runs sampled)

Running Benchmark Suite for test - All object 10 ...
- [All object 10] platform x 11,439 ops/sec ±4.80% (53 runs sampled)
- [All object 10] rsvp-2.0.4 x 25,869 ops/sec ±13.63% (49 runs sampled)
- [All object 10] rsvp-3.0.0 x 33,379 ops/sec ±9.16% (45 runs sampled)
- [All object 10] rsvp-3.0.6 x 26,962 ops/sec ±5.21% (52 runs sampled)
- [All object 10] rsvp x 70,673 ops/sec ±7.85% (46 runs sampled)

Running Benchmark Suite for test - All object 100 ...
- [All object 100] platform x 1,278 ops/sec ±5.45% (53 runs sampled)
- [All object 100] rsvp-2.0.4 x 19,990 ops/sec ±13.51% (39 runs sampled)
- [All object 100] rsvp-3.0.0 x 4,581 ops/sec ±7.73% (51 runs sampled)
- [All object 100] rsvp-3.0.6 x 4,934 ops/sec ±8.09% (48 runs sampled)
- [All object 100] rsvp x 8,959 ops/sec ±6.05% (46 runs sampled)

Running Benchmark Suite for test - All object 1000 ...
- [All object 1000] platform x 127 ops/sec ±3.52% (52 runs sampled)
- [All object 1000] rsvp-2.0.4 x 6,526 ops/sec ±10.40% (36 runs sampled)
- [All object 1000] rsvp-3.0.0 x 463 ops/sec ±9.11% (49 runs sampled)
- [All object 1000] rsvp-3.0.6 x 507 ops/sec ±8.08% (49 runs sampled)
- [All object 1000] rsvp x 990 ops/sec ±6.05% (50 runs sampled)

Running Benchmark Suite for test - All object 10000 ...
- [All object 10000] platform x 8.60 ops/sec ±7.72% (45 runs sampled)
- [All object 10000] rsvp-2.0.4 x 366 ops/sec ±16.04% (32 runs sampled)
- [All object 10000] rsvp-3.0.0 x 14.81 ops/sec ±16.51% (47 runs sampled)
- [All object 10000] rsvp-3.0.6 x 42.87 ops/sec ±10.36% (43 runs sampled)
- [All object 10000] rsvp x 58.32 ops/sec ±13.41% (44 runs sampled)

Running Benchmark Suite for test - All thenable 1 ...
- [All thenable 1] platform x 79,560 ops/sec ±3.83% (54 runs sampled)
- [All thenable 1] rsvp-2.0.4 x 1,925 ops/sec ±99.45% (5 runs sampled)
- [All thenable 1] rsvp-3.0.0 x 116,369 ops/sec ±25.11% (45 runs sampled)
- [All thenable 1] rsvp-3.0.6 x 65,783 ops/sec ±23.88% (26 runs sampled)
- [All thenable 1] rsvp x 131,863 ops/sec ±16.46% (49 runs sampled)

Running Benchmark Suite for test - All thenable 2 ...
- [All thenable 2] platform x 30,848 ops/sec ±1.89% (53 runs sampled)
- [All thenable 2] rsvp-2.0.4 x 1,832 ops/sec ±18.87% (17 runs sampled)
- [All thenable 2] rsvp-3.0.0 x 17,433 ops/sec ±2.62% (33 runs sampled)
- [All thenable 2] rsvp-3.0.6 x 13,023 ops/sec ±2.11% (48 runs sampled)
- [All thenable 2] rsvp x 91,849 ops/sec ±42.13% (13 runs sampled)

Running Benchmark Suite for test - All thenable 10 ...
- [All thenable 10] platform x 9,589 ops/sec ±5.60% (51 runs sampled)
- [All thenable 10] rsvp-2.0.4 x 673 ops/sec ±11.26% (32 runs sampled)
- [All thenable 10] rsvp-3.0.0 x 7,082 ops/sec ±2.85% (51 runs sampled)
- [All thenable 10] rsvp-3.0.6 x 8,146 ops/sec ±13.79% (38 runs sampled)
- [All thenable 10] rsvp x 38,762 ops/sec ±4.23% (53 runs sampled)

Running Benchmark Suite for test - All thenable 100 ...
- [All thenable 100] platform x 1,832 ops/sec ±6.92% (53 runs sampled)
- [All thenable 100] rsvp-2.0.4 x 195 ops/sec ±26.38% (17 runs sampled)
- [All thenable 100] rsvp-3.0.0 x 2,470 ops/sec ±35.56% (10 runs sampled)
- [All thenable 100] rsvp-3.0.6 x 4,362 ops/sec ±34.46% (35 runs sampled)
- [All thenable 100] rsvp x 12,997 ops/sec ±24.69% (49 runs sampled)

Running Benchmark Suite for test - All thenable 1000 ...
- [All thenable 1000] platform x 188 ops/sec ±5.97% (49 runs sampled)
- [All thenable 1000] rsvp-2.0.4 x 33.97 ops/sec ±20.36% (29 runs sampled)
- [All thenable 1000] rsvp-3.0.0 x 172 ops/sec ±54.74% (25 runs sampled)
- [All thenable 1000] rsvp-3.0.6 x 259 ops/sec ±40.37% (27 runs sampled)
- [All thenable 1000] rsvp x 288 ops/sec ±51.20% (49 runs sampled)

Running Benchmark Suite for test - All thenable 10000 ...
- [All thenable 10000] platform x 9.73 ops/sec ±5.01% (48 runs sampled)
- [All thenable 10000] rsvp-2.0.4 x 4.40 ops/sec ±29.96% (25 runs sampled)
- [All thenable 10000] rsvp-3.0.0 x 28.50 ops/sec ±52.28% (30 runs sampled)
- [All thenable 10000] rsvp-3.0.6 x 27.86 ops/sec ±59.24% (20 runs sampled)
- [All thenable 10000] rsvp x 127 ops/sec ±27.79% (44 runs sampled)

Running Benchmark Suite for test - Creation 1 ...
- [Creation 1] platform x 582,984 ops/sec ±4.60% (57 runs sampled)
- [Creation 1] rsvp-2.0.4 x 245,733 ops/sec ±9.52% (56 runs sampled)
- [Creation 1] rsvp-3.0.0 x 5,547,374 ops/sec ±2.93% (58 runs sampled)
- [Creation 1] rsvp-3.0.6 x 5,236,891 ops/sec ±2.19% (56 runs sampled)
- [Creation 1] rsvp x 4,835,237 ops/sec ±5.33% (55 runs sampled)

Running Benchmark Suite for test - filter false 1 ...
- [filter false 1] rsvp-3.0.6 x 114,896 ops/sec ±4.22% (55 runs sampled)
- [filter false 1] rsvp x 142,518 ops/sec ±4.02% (53 runs sampled)

Running Benchmark Suite for test - filter false 2 ...
- [filter false 2] rsvp-3.0.6 x 109,540 ops/sec ±7.90% (32 runs sampled)
- [filter false 2] rsvp x 140,934 ops/sec ±5.31% (51 runs sampled)

Running Benchmark Suite for test - filter false 10 ...
- [filter false 10] rsvp-3.0.6 x 102,817 ops/sec ±5.08% (53 runs sampled)
- [filter false 10] rsvp x 131,556 ops/sec ±4.30% (53 runs sampled)

Running Benchmark Suite for test - filter false 100 ...
- [filter false 100] rsvp-3.0.6 x 55,702 ops/sec ±4.96% (51 runs sampled)
- [filter false 100] rsvp x 78,282 ops/sec ±5.80% (50 runs sampled)

Running Benchmark Suite for test - filter false 1000 ...
- [filter false 1000] rsvp-3.0.6 x 10,573 ops/sec ±4.08% (53 runs sampled)
- [filter false 1000] rsvp x 16,416 ops/sec ±7.35% (49 runs sampled)

Running Benchmark Suite for test - filter false 10000 ...
- [filter false 10000] rsvp-3.0.6 x 1,202 ops/sec ±4.17% (51 runs sampled)
- [filter false 10000] rsvp x 1,907 ops/sec ±7.32% (49 runs sampled)

Running Benchmark Suite for test - filter with promiseFn 1 ...
- [filter with promiseFn 1] rsvp-3.0.6 x 95,276 ops/sec ±6.79% (51 runs sampled)
- [filter with promiseFn 1] rsvp x 116,584 ops/sec ±5.41% (50 runs sampled)

Running Benchmark Suite for test - filter with promiseFn 2 ...
- [filter with promiseFn 2] rsvp-3.0.6 x 76,926 ops/sec ±5.51% (49 runs sampled)
- [filter with promiseFn 2] rsvp x 102,216 ops/sec ±6.32% (48 runs sampled)

Running Benchmark Suite for test - filter with promiseFn 10 ...
- [filter with promiseFn 10] rsvp-3.0.6 x 36,068 ops/sec ±6.91% (50 runs sampled)
- [filter with promiseFn 10] rsvp x 52,145 ops/sec ±5.24% (47 runs sampled)

Running Benchmark Suite for test - filter with promiseFn 100 ...
- [filter with promiseFn 100] rsvp-3.0.6 x 4,725 ops/sec ±8.44% (35 runs sampled)
- [filter with promiseFn 100] rsvp x 8,087 ops/sec ±7.25% (49 runs sampled)

Running Benchmark Suite for test - filter with promiseFn 1000 ...
- [filter with promiseFn 1000] rsvp-3.0.6 x 506 ops/sec ±7.90% (49 runs sampled)
- [filter with promiseFn 1000] rsvp x 917 ops/sec ±6.51% (51 runs sampled)

Running Benchmark Suite for test - filter with promiseFn 10000 ...
- [filter with promiseFn 10000] rsvp-3.0.6 x 51.77 ops/sec ±7.66% (51 runs sampled)
- [filter with promiseFn 10000] rsvp x 90.41 ops/sec ±6.26% (49 runs sampled)

Running Benchmark Suite for test - filter true 1 ...
- [filter true 1] rsvp-3.0.6 x 113,008 ops/sec ±5.33% (45 runs sampled)
- [filter true 1] rsvp x 138,437 ops/sec ±6.05% (49 runs sampled)

Running Benchmark Suite for test - filter true 2 ...
- [filter true 2] bluebird x 390,454 ops/sec ±5.70% (54 runs sampled)
- [filter true 2] rsvp-3.0.6 x 115,404 ops/sec ±5.11% (49 runs sampled)
- [filter true 2] rsvp x 137,926 ops/sec ±4.95% (51 runs sampled)

Running Benchmark Suite for test - filter true 10 ...
- [filter true 10] rsvp-3.0.6 x 100,666 ops/sec ±5.94% (54 runs sampled)
- [filter true 10] rsvp x 126,957 ops/sec ±4.44% (50 runs sampled)

Running Benchmark Suite for test - filter true 100 ...
- [filter true 100] bluebird x 88,265 ops/sec ±4.25% (52 runs sampled)
- [filter true 100] rsvp-3.0.6 x 52,095 ops/sec ±8.04% (49 runs sampled)
- [filter true 100] rsvp x 73,543 ops/sec ±5.03% (50 runs sampled)
Fastest for filter true 100 is 
Array[1]
Running Benchmark Suite for test - filter true 1000 ...
- [filter true 1000] bluebird x 11,540 ops/sec ±4.82% (52 runs sampled)
- [filter true 1000] rsvp-3.0.6 x 8,675 ops/sec ±7.06% (49 runs sampled)
- [filter true 1000] rsvp x 14,303 ops/sec ±7.74% (50 runs sampled)

Running Benchmark Suite for test - filter true 10000 ...
- [filter true 10000] rsvp-3.0.6 x 1,072 ops/sec ±5.18% (50 runs sampled)
- [filter true 10000] rsvp x 1,523 ops/sec ±9.56% (47 runs sampled)

Running Benchmark Suite for test - Reject 1 ...
- [Reject 1] rsvp-2.0.4 x 31,789 ops/sec ±7.86% (46 runs sampled)
- [Reject 1] rsvp-3.0.0 x 302,989 ops/sec ±7.01% (47 runs sampled)
- [Reject 1] rsvp-3.0.6 x 394,058 ops/sec ±7.34% (50 runs sampled)
- [Reject 1] rsvp x 480,353 ops/sec ±4.40% (51 runs sampled)

Running Benchmark Suite for test - Resolve 1 ...
- [Resolve 1] rsvp-2.0.4 x 35,270 ops/sec ±7.07% (48 runs sampled)
- [Resolve 1] rsvp-3.0.0 x 305,753 ops/sec ±7.85% (49 runs sampled)
- [Resolve 1] rsvp-3.0.6 x 378,555 ops/sec ±6.15% (47 runs sampled)
- [Resolve 1] rsvp x 451,985 ops/sec ±3.89% (48 runs sampled)

Running Benchmark Suite for test - Resolve Promise 1 ...
- [Resolve Promise 1] rsvp-2.0.4 x 4,575 ops/sec ±46.04% (14 runs sampled)
- [Resolve Promise 1] rsvp-3.0.0 x 154,747 ops/sec ±9.52% (49 runs sampled)
- [Resolve Promise 1] rsvp-3.0.6 x 189,956 ops/sec ±11.03% (45 runs sampled)
- [Resolve Promise 1] rsvp x 329,175 ops/sec ±2.72% (53 runs sampled)
```
