### PR TITLE
pass jshint

### DIFF
--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -1,11 +1,11 @@
-var length = 0;
+var len = 0;
 
 export default function asap(callback, arg) {
-  queue[length] = callback;
-  queue[length + 1] = arg;
-  length += 2
-  if (length === 2) {
-    // If length is 1, that means that we need to schedule an async flush.
+  queue[len] = callback;
+  queue[len + 1] = arg;
+  len += 2;
+  if (len === 2) {
+    // If len is 1, that means that we need to schedule an async flush.
     // If additional callbacks are queued before the queue is flushed, they
     // will be processed by this flush that we are scheduling.
     scheduleFlush();
@@ -55,7 +55,7 @@ function useSetTimeout() {
 
 var queue = new Array(1000);
 function flush() {
-  for (var i = 0; i < length; i+=2) {
+  for (var i = 0; i < len; i+=2) {
     var callback = queue[i];
     var arg = queue[i+1];
 
@@ -65,7 +65,7 @@ function flush() {
     queue[i+1] = undefined;
   }
 
-  length = 0;
+  len = 0;
 }
 
 var scheduleFlush;


### PR DESCRIPTION
jshint has length as a global variable in the browser, so renaming the variable which is in the asap file to len even though in context it won't be an actually global variable.
