### PR TITLE
Remove variables that are no longer used

### DIFF
--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -187,8 +187,7 @@ export default {
     the given `eventName`
   */
   trigger: function(eventName, options) {
-    var allCallbacks = callbacksFor(this),
-        callbacks, callbackTuple, callback, binding;
+    var allCallbacks = callbacksFor(this), callbacks, callback;
 
     if (callbacks = allCallbacks[eventName]) {
       // Don't cache the callbacks.length since it may grow


### PR DESCRIPTION
Simply removes the declaration of variables no longer used by the implementation of `trigger`.
