### PR TITLE
Add `RSVP.sequence` for executing sequence of promises in order

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -1,6 +1,7 @@
 import Promise from "./rsvp/promise";
 import EventTarget from "./rsvp/events";
 import denodeify from "./rsvp/node";
+import sequence from "./rsvp/sequence";
 import all from "./rsvp/all";
 import allSettled from "./rsvp/all-settled";
 import race from "./rsvp/race";
@@ -44,6 +45,7 @@ export {
   Promise,
   EventTarget,
   all,
+  sequence,
   allSettled,
   race,
   hash,

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -22,6 +22,7 @@ import {
 
 import cast from './promise/cast';
 import all from './promise/all';
+import sequence from './promise/sequence';
 import race from './promise/race';
 import Resolve from './promise/resolve';
 import Reject from './promise/reject';
@@ -165,6 +166,7 @@ function Promise(resolver, label) {
 
 Promise.cast = cast;
 Promise.all = all;
+Promise.sequence = sequence;
 Promise.race = race;
 Promise.resolve = Resolve;
 Promise.reject = Reject;

--- a/lib/rsvp/promise/sequence.js
+++ b/lib/rsvp/promise/sequence.js
@@ -1,0 +1,11 @@
+export default function sequence(promises) {
+    var functions = promises.map(function(promise){
+        return function(){
+            return promise;
+        };
+    });
+
+    return functions.reduce(function(current, next){
+        return current.then(next);
+    }, RSVP.resolve());
+}

--- a/lib/rsvp/sequence.js
+++ b/lib/rsvp/sequence.js
@@ -1,0 +1,15 @@
+import Promise from "./promise";
+
+/**
+  This is a convenient alias for `RSVP.Promise.all`.
+
+  @method all
+  @static
+  @for RSVP
+  @param {Array} array Array of promises.
+  @param {String} label An optional label. This is useful
+  for tooling.
+*/
+export default function sequence(array, label) {
+  return Promise.sequence(array, label);
+}


### PR DESCRIPTION
Hi,

Sometimes I need to execute a list of promises in an specific order. `RSVP.all` invokes all the promises at the same time, and this can be a problem depending on the async operation performed. For example, with IndexedDB, executing thousands of write operations at the same time is really bad for performance.

This PR adds a `RSVP.sequence` method to execute a sequence of promises in order. It is undocumented and untested but I wanted to know if you would be interested in something like this first. It is based on [this proposal](http://stackoverflow.com/questions/20100245/how-can-i-execute-array-of-promises-in-sequential-order). I think it's an addition that makes sense for RSVP.

If you are interested I can add some tests and documentation for the method.
