### PR TITLE
Add version comment block to distributed files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,3 +1,5 @@
+var calculateVersion = require('./lib/calculateVersion');
+
 module.exports = function(grunt) {
   var config = require('load-grunt-config')(grunt, {
     configPath: 'tasks/options',
@@ -40,7 +42,8 @@ module.exports = function(grunt) {
     'concat:browser',
     'browser:distNoVersion',
     'jshint',
-    'uglify:browser'
+    'uglify:browser',
+    'versionFiles'
   ]);
 
   // Custom phantomjs test task
@@ -69,7 +72,8 @@ module.exports = function(grunt) {
     'concat:browser',
     'browser:distNoVersion',
     'concat:amdNoVersion',
-    'uglify:browserNoVersion'
+    'uglify:browserNoVersion',
+    'versionFiles'
   ]);
 
   // Custom YUIDoc task
@@ -87,4 +91,5 @@ module.exports = function(grunt) {
 
   // Merge config into emberConfig, overwriting existing settings
   grunt.initConfig(config);
+  grunt.config('versionStamp', calculateVersion());
 };

--- a/config/versionTemplate.txt
+++ b/config/versionTemplate.txt
@@ -1,0 +1,9 @@
+/*!
+ * @overview RSVP - a tiny implementation of Promises/A+.
+ * @copyright Copyright 2011-2014 Tilde Inc. and contributors
+ *            Portions Copyright 2006-2011 Strobe Inc.
+ *            Portions Copyright 2008-2011 Apple Inc. All rights reserved.
+ * @license   Licensed under MIT license
+ *            See https://raw.githubusercontent.com/tildeio/rsvp.js/master/LICENSE
+ * @version   <%= versionStamp %>
+ */

--- a/lib/calculateVersion.js
+++ b/lib/calculateVersion.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var fs   = require('fs');
+var path = require('path');
+
+module.exports = function () {
+  var packageVersion = require('../package.json').version;
+  var output         = [packageVersion];
+  var gitPath        = path.join(__dirname,'..','.git');
+  var headFilePath   = path.join(gitPath, 'HEAD');
+
+  if (packageVersion.indexOf('+') > -1) {
+    try {
+      if (fs.existsSync(headFilePath)) {
+        var headFile = fs.readFileSync(headFilePath, {encoding: 'utf8'});
+        var branchName = headFile.split('/').slice(-1)[0].trim();
+        var refPath = headFile.split(' ')[1];
+        var branchSHA;
+
+        if (refPath) {
+          var branchPath = path.join(gitPath, refPath.trim());
+          branchSHA  = fs.readFileSync(branchPath);
+        } else {
+          branchSHA = branchName;
+        }
+
+        output.push(branchSHA.slice(0,10));
+      }
+    } catch (err) {
+      console.error(err.stack);
+    }
+    return output.join('.');
+  } else {
+    return packageVersion;
+  }
+};

--- a/tasks/options/versionFiles.js
+++ b/tasks/options/versionFiles.js
@@ -1,0 +1,14 @@
+module.exports = {
+  browser: {
+    src: 'dist/<%= pkg.name %>.js',
+    dest: 'dist/<%= pkg.name %>.js'
+  },
+  amd: {
+    src: 'dist/<%= pkg.name %>.amd.js',
+    dest: 'dist/<%= pkg.name %>.amd.js'
+  },
+  min: {
+    src: 'dist/<%= pkg.name %>.min.js',
+    dest: 'dist/<%= pkg.name %>.min.js'
+  }
+};

--- a/tasks/versionFiles.js
+++ b/tasks/versionFiles.js
@@ -1,0 +1,9 @@
+module.exports = function(grunt) {
+  grunt.registerMultiTask('versionFiles', 'Place comment version at top of distribution files', function() {
+    this.files.forEach(function(f) {
+      var header = grunt.template.process(grunt.file.read(__dirname + "/../config/versionTemplate.txt"))
+      var body = f.src.map(grunt.file.read);
+      grunt.file.write(f.dest, [header, body].join('\n'));
+    });
+  });
+};


### PR DESCRIPTION
The goal of this commit is to ensure that the files distributed via S3 have proper versioning associated with them.  

This is to help unify the publishing of Ember micro-libs under the ember-publisher project.   At some point I will likely attempt to modularize the calculateVersion file, as it is used by ember / ember-data  and now rsvp.  

If anyone is interested I'd be happy to review this PR with them.  Thanks. :)))))
