### PR TITLE
Update bower.json to allow lib through on bower install

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,14 +12,11 @@
   ],
   "license": "MIT",
   "ignore": [
-    "**/.*",
     "node_modules",
     "bower_components",
     "test",
     "tests",
     "vendor",
-    "tasks",
-    "macros",
-    "lib"
+    "tasks"
   ]
 }


### PR DESCRIPTION
Moving the process by which ember.js includes microlibs such as RSVP to bower components.  Then in the brocfile processing the es6 code.  An example can be found [here](https://github.com/emberjs/ember.js/pull/5216) (with backburner).  

In [this commit](https://github.com/tildeio/rsvp.js/commit/a82f2b25651b56b2f7e44d92cdf3b3005ec07452) the components.json file was renamed to bower.json and several files were ignored.  I've removed the ignore props that prevent the inclusion of lib.  

With this bower.json I was able to test locally the inclusion of RSVP (mentioned earlier) in ember.js.  Though I'm not sure why these files were ignored, so I'm not entirely certain of the implications of allowing those files through. Any clarification would be most welcome.  

The components/rsvp repo has its own bower.json (possibly relevant)

Thanks!
