### PR TITLE
Use ember-publisher to publish rsvp/rsvp.min to s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@
 language: node_js
 node_js:
 - '0.10'
-before_install:
+after_success:
+  - "./bin/publish_to_s3.js"
 env:
   global:
   - secure: |-

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -25,7 +25,7 @@ trees.push(compileModules('lib', {
   formatter: new AMDFormatter()
 }));
 
-if (process.env.ENV === 'production') {
+if (process.env.EMBER_ENV === 'production') {
   trees.push(closureCompiler(moveFile(bundle, {
     srcFile: 'rsvp.js',
     destFile: 'rsvp.min.js'
@@ -45,7 +45,7 @@ distTrees.push(concat(distTree, {
   outputFile: '/rsvp.js'
 }));
 
-if (process.env.ENV === 'production') {
+if (process.env.EMBER_ENV === 'production') {
   distTrees.push(concat(distTree, {
     inputFiles: [
       'versionTemplate.txt',
@@ -54,7 +54,6 @@ if (process.env.ENV === 'production') {
     outputFile: '/rsvp.min.js'
   }));
 }
-
 
 distTree = mergeTrees(distTrees);
 var distTree = replace(distTree, {

--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+// To invoke this from the commandline you need the following to env vars to exist:
+//
+// S3_BUCKET_NAME
+// TRAVIS_BRANCH
+// TRAVIS_TAG
+// TRAVIS_COMMIT
+// S3_SECRET_ACCESS_KEY
+// S3_ACCESS_KEY_ID
+//
+// Once you have those you execute with the following:
+//
+// ```sh
+// ./bin/publish_to_s3.js
+// ```
+var S3Publisher = require('ember-publisher');
+var configPath = require('path').join(__dirname, '../config/s3ProjectConfig.js');
+publisher = new S3Publisher({projectConfigPath: configPath});
+
+// Always use wildcard section of project config.
+// This is useful when the including library does not
+// require channels (like in ember.js / ember-data).
+publisher.currentBranch = function() {
+  return (process.env.TRAVIS_BRANCH === 'master') ? 'wildcard' : 'no-op';
+};
+publisher.publish();
+

--- a/config/s3ProjectConfig.js
+++ b/config/s3ProjectConfig.js
@@ -1,0 +1,26 @@
+/*
+ * Using wildcard because RSVP does not currently have a
+ * channel system in place.
+ */
+module.exports = function(revision,tag,date){
+  return {
+    'rsvp.js':
+      { contentType: 'text/javascript',
+        destinations: {
+          wildcard: [
+            'rsvp-latest.js',
+            'rsvp-' + revision + '.js'
+          ]
+        }
+      },
+    'rsvp.min.js':
+      { contentType: 'text/javascript',
+        destinations: {
+          wildcard: [
+            'rsvp-latest.min.js',
+            'rsvp-' + revision + '.min.js'
+          ]
+        }
+      }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "broccoli-string-replace": "0.0.1",
     "browserify": "^4.2.0",
     "ember-cli": "0.0.37",
+    "ember-publisher": "0.0.6",
     "es6-module-transpiler-amd-formatter": "0.0.1",
     "express": "^4.5.0",
     "jshint": "~0.9.1",
@@ -31,9 +32,9 @@
     "test": "testem ci",
     "test-server": "testem",
     "lint": "jshint lib",
-    "prepublish": "ember build",
+    "prepublish": "ember build --environment production",
     "aplus": "browserify test/main.js",
-    "build-all": "ember build && browserify ./test/main.js -o tmp/test-bundle.js"
+    "build-all": "ember build --environment production && browserify ./test/main.js -o tmp/test-bundle.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will publish the following routes on every successful push to the master branch:
- 'rsvp-latest.js'
- 'rsvp-' + revision + '.js'
- 'rsvp-latest.min.js',
- 'rsvp-' + revision + '.min.js'

More details can be found [here](https://github.com/rondale-sc/ember-publisher/blob/master/project_configs/rsvp-proj.js)

In the bin script I am forcing the currentBranch to use the wildcard only when current branch is master.   On other branches it will fail [here](https://github.com/rondale-sc/ember-publisher/blob/master/index.js#L76).

The environment variables are already available from [this](https://github.com/tildeio/rsvp.js/commit/ea2263764439df4569ff4efd9a80c87ccdb3184a#diff-354f30a63fb0907d4ad57269548329e3R10)

Cheers
