### PR TITLE
Use existing s3 credentials from Travis.yml

### DIFF
--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -16,7 +16,11 @@
 // ```
 var S3Publisher = require('ember-publisher');
 var configPath = require('path').join(__dirname, '../config/s3ProjectConfig.js');
-publisher = new S3Publisher({projectConfigPath: configPath});
+publisher = new S3Publisher({
+  projectConfigPath: configPath,
+  S3_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+  S3_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY
+});
 
 // Always use wildcard section of project config.
 // This is useful when the including library does not


### PR DESCRIPTION
https://github.com/tildeio/rsvp.js/commit/ea2263764439df4569ff4efd9a80c87ccdb3184a Added grunt s3 integration.  You'll notice that in this commit there are two encrypted variables that were added to the `.travis.yml` file.  The default variable names for `grunt-s3` can be found [here](https://github.com/pifantastic/grunt-s3#environment-variables).  

I've simply set the `ember-publisher` credentials to the ones we know exist from our exploration (see above).

Cheers
