### PR TITLE
Ensure S3_BUCKET_NAME is set for publisher

### DIFF
--- a/bin/publish_to_s3.js
+++ b/bin/publish_to_s3.js
@@ -18,6 +18,7 @@ var S3Publisher = require('ember-publisher');
 var configPath = require('path').join(__dirname, '../config/s3ProjectConfig.js');
 publisher = new S3Publisher({
   projectConfigPath: configPath,
+  S3_BUCKET_NAME: 'rsvpjs-builds',
   S3_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
   S3_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY
 });


### PR DESCRIPTION
Hopefully the last of the AWS credentials problems. 

 In [this commit](https://github.com/tildeio/rsvp.js/commit/ea2263764439df4569ff4efd9a80c87ccdb3184a#diff-33b8a1813390dcde555d5ce4098e61b8R13) the `bucket` is set to  `rsvpjs-builds`.  This PR just sets that for ember-publisher as well.

I should have added this to https://github.com/tildeio/rsvp.js/pull/272...

![shower-cat](https://cloud.githubusercontent.com/assets/75710/3766767/acf5368e-18c7-11e4-9b0c-d20852cc1155.gif)
