### PR TITLE
Update ember-publisher to ensure ACL is set to public-read

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "broccoli-string-replace": "0.0.1",
     "browserify": "^4.2.0",
     "ember-cli": "0.0.37",
-    "ember-publisher": "0.0.6",
+    "ember-publisher": "0.0.7",
     "es6-module-transpiler-amd-formatter": "0.0.1",
     "express": "^4.5.0",
     "jshint": "~0.9.1",


### PR DESCRIPTION
For whatever reason the RSVP.js bucket will not apply the folder permissions onto the individual files, so ember publisher had to update in order  to set the Access Control List permissions on a per file basis to `public-read`.  

This should ensure that each push sets the permissions correctly for published files.

Moar deets [here](https://github.com/rondale-sc/ember-publisher/pull/8)
