### PR TITLE
Unhandled rejections not reported by error handler

### DIFF
--- a/test/tests/extension-test.js
+++ b/test/tests/extension-test.js
@@ -1063,6 +1063,26 @@ describe("RSVP extensions", function() {
         done();
       });
     });
+
+    it("When provided, any unhandled exceptions are sent to it, even from inside error handlers", function(done) {
+      var firstError = new Error();
+      var secondError = new Error();
+
+      RSVP.on('error', function(reason) {
+        assert.equal(reason, secondError, "The thrown error is passed in");
+        done();
+      });
+
+      new RSVP.Promise(function(resolve, reject) {
+        reject(firstError);
+      }).catch(function(err){
+        assert.equal(err, firstError, "The first error is handled");
+        return new RSVP.Promise(function(resolve, reject){
+          reject(secondError);
+        });
+      });
+    });
+
   });
 
   function assertRejection(promise) {


### PR DESCRIPTION
Here is a failing unit test based on a situation I encountered in an application. `RSVP.on('error', ...)` fails to report unhandled rejections if they originate inside other error handlers.

The failure is correctly propagated out to the top-most level, where it is definitely not being handled by anything. So this seems like a bug.
