### PR TITLE
add some tooling for making releasing earlier

### DIFF
--- a/.release.json
+++ b/.release.json
@@ -1,0 +1,17 @@
+{
+  "non-interactive": true,
+  "dry-run": false,
+  "verbose": false,
+  "force": false,
+  "pkgFiles": ["package.json", "bower.json"],
+  "increment": "patch",
+  "commitMessage": "Release %s",
+  "tagName": "%s",
+  "tagAnnotation": "Release %s",
+  "buildCommand": "npm run-script build-all",
+  "distRepo": "git@github.com:components/rsvp.js.git",
+  "distStageDir": "tmp/stage",
+  "distBase": "dist",
+  "distFiles": ["**/*", "../package.json", "../bower.json"],
+  "publish": false
+}

--- a/README.md
+++ b/README.md
@@ -337,3 +337,8 @@ Custom tasks:
 * `ember build` - Build distribution
 * `testem ci` - Run tests.
 * `testem` - Run test server.
+
+## Releasing
+
+Check what release-it will do by running `npm run-script dry-run-release`.
+To actually release, run `node_modules/.bin/release-it`.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rsvp.js",
-  "version": "3.0.7",
+  "version": "3.0.11",
   "homepage": "https://github.com/tildeio/rsvp.js",
   "authors": [
     "Stefan Penner <stefan.penner@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mkdirp": "^0.5.0",
     "mocha": "^1.20.1",
     "promises-aplus-tests": "git://github.com/stefanpenner/promises-tests.git",
+    "release-it": "0.0.10",
     "testem": "^0.6.17"
   },
   "scripts": {
@@ -34,7 +35,8 @@
     "lint": "jshint lib",
     "prepublish": "ember build --environment production",
     "aplus": "browserify test/main.js",
-    "build-all": "ember build --environment production && browserify ./test/main.js -o tmp/test-bundle.js"
+    "build-all": "ember build --environment production && browserify ./test/main.js -o tmp/test-bundle.js",
+    "dry-run-release": "ember build --environment production && release-it --dry-run --non-interactive"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Unfortunately, we can't use `scripts` for the release it unless we want no-interactive on. npm-scripts doesn't seem to allow for interactivity.
