### PR TITLE
Add vert.x compatibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * add `finally` to the readme
 * improve usage of browserify for promise/a+ tests
 * add wasteful files to gitignore
+* add [vert.x](http://vertx.io/) compatibility
 
 # 3.0.13
 

--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -27,6 +27,13 @@ function useNextTick() {
   };
 }
 
+// vertx
+function useVertxTimer() {
+  return function() {
+    vertxNext(flush);
+  };
+}
+
 function useMutationObserver() {
   var iterations = 0;
   var observer = new BrowserMutationObserver(flush);
@@ -77,6 +84,14 @@ if (typeof process !== 'undefined' && {}.toString.call(process) === '[object pro
   scheduleFlush = useMutationObserver();
 } else if (isWorker) {
   scheduleFlush = useMessageChannel();
+} else if (typeof require === 'function') {
+  try {
+    var vertx = require('vertx');
+    var vertxNext = vertx.runOnLoop || vertx.runOnContext;
+    scheduleFlush = useVertxTimer();
+  } catch(e) {
+    scheduleFlush = useSetTimeout();
+  }
 } else {
   scheduleFlush = useSetTimeout();
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "test-server": "testem",
     "lint": "jshint lib",
     "prepublish": "ember build --environment production",
-    "aplus": "browserify test/main.js",
-    "build-all": "ember build --environment production && browserify ./test/main.js -o tmp/test-bundle.js",
+    "aplus": "browserify test/main.js -x vertx",
+    "build-all": "ember build --environment production && browserify ./test/main.js -x vertx -o tmp/test-bundle.js",
     "dry-run-release": "ember build --environment production && release-it --dry-run --non-interactive"
   },
   "repository": {

--- a/vertx.js
+++ b/vertx.js
@@ -1,0 +1,1 @@
+// to make browserify happy about trying to require('vertx')


### PR DESCRIPTION
This pull requests adds compatibility with [vert.x](http://vertx.io/). Vert.x uses its own timers instead of setTimeout but fortunately only a small addition is needed to make rsvp.js compatible with vert.x. I tried to orient my changes on the way rsvp checks for the availability of web workers but I think it is necessary to put the vertx require inside a try/catch because there is no vertx package but vert.x comes with its own module system.

I also needed to tweak the browserify options ins package.json so that browserify stops complaining about requiring vert.x in rsvp.js-source and add an empty vertx-file.

Hope this is useful. I would be happy to add meaningful tests for this but I am not sure how to test this properly because this only checks if it is possible to require vert.x and then uses the vert.x's timer instead of setTimeout.
