### PR TITLE
improve cost of instrumentation by up to 75x in chrome

### DIFF
--- a/lib/rsvp/instrument.js
+++ b/lib/rsvp/instrument.js
@@ -13,7 +13,9 @@ function scheduleFlush() {
 
       payload.guid = payload.key + payload.id;
       payload.childGuid = payload.key + payload.childId;
-      payload.stack = payload.error.stack;
+      if (payload.error) {
+        payload.stack = payload.error.stack;
+      }
 
       config.trigger(entry.name, entry.payload);
     }
@@ -32,7 +34,7 @@ export default function instrument(eventName, promise, child) {
         childId: child && child._id,
         label: promise._label,
         timeStamp: now(),
-        error: new Error(promise._label)
+        error: config["instrument-with-stack"] ? new Error(promise._label) : null
       }})) {
         scheduleFlush();
       }


### PR DESCRIPTION
Note: This is only enabled if someone engages the inspector, or manually enables instrumentation.

@teddyzeenny I know we show the "Stack" in the inspector, but it is extremely costly even with this PR. Do you think we could add an additional checkbox for "show stack" in the inspector and then more granular config in ember-inspector?

Additionally, the stack currently is very often not-very-useful. Someday when the browser implement the virtual callstack tagging, it will be more useful. Or if we move to add the very slow long-stack trace support. Likely both of these scenarios would benefit from an additional checkbox akin to `async` in the chrome inspector but named `show stacks`

---

With @teddyzeenny's addition we now split "stack" and "non-stack" instrumentation, as stack comes at a massive cost (even with the 15x improvement above) With stack disabled the cost of instrumentation is only about 5x slower.
