### PR TITLE
Instrumentation with stack is now opt-in

### DIFF
--- a/lib/rsvp/instrument.js
+++ b/lib/rsvp/instrument.js
@@ -13,7 +13,9 @@ function scheduleFlush() {
 
       payload.guid = payload.key + payload.id;
       payload.childGuid = payload.key + payload.childId;
-      payload.stack = payload.error.stack;
+      if (payload.error) {
+        payload.stack = payload.error.stack;
+      }
 
       config.trigger(entry.name, entry.payload);
     }
@@ -32,7 +34,7 @@ export default function instrument(eventName, promise, child) {
         childId: child && child._id,
         label: promise._label,
         timeStamp: now(),
-        error: new Error(promise._label)
+        error: config["instrument-with-stack"] ? new Error(promise._label) : null
       }})) {
         scheduleFlush();
       }


### PR DESCRIPTION
To improve performance, the default is now not to track stack with promises.

To include the stack in instrumentation:
`RSVP.configure('instrument-with-stack', true);`

Related: https://github.com/emberjs/ember-inspector/pull/232

/ cc @stefanpenner 
