### PR TITLE
Fix onerror test

### DIFF
--- a/test/tests/extension-test.js
+++ b/test/tests/extension-test.js
@@ -1354,12 +1354,10 @@ describe("RSVP extensions", function() {
     it("zalgo: When provided, unhandled exceptions are sent to it", function(done) {
       var thrownError = new Error();
 
-      var didOnError = false;
-      var reason;
-
       RSVP.configure('onerror', function(error) {
-        didOnError = true;
-        reason = error;
+        assert(true, "should also have emitted onerror");
+        assert.equal(error, thrownError, "The handler should handle the error");
+        done();
       });
 
       var rejected = RSVP.Promise.reject(thrownError);
@@ -1367,24 +1365,14 @@ describe("RSVP extensions", function() {
       RSVP.Promise.resolve().then(function(){
         return rejected;
       });
-
-      setTimeout(function(){
-
-        assert(didOnError, "should also have emitted onerror");
-        assert.equal(reason, thrownError, "The handler should handle the error");
-
-        done();
-      }, 100);
     });
 
 
     it("assimilation: When provided, unhandled exceptions are sent to it", function(done) {
       var thrownError = new Error();
 
-      var count = 0;
       RSVP.configure('onerror', function(error) {
-        count++;
-        assert(count === 1, "Should get here once");
+        assert(true, "Should get here once");
         done();
       });
 
@@ -1415,6 +1403,24 @@ describe("RSVP extensions", function() {
         });
       });
     });
+
+    it('does not emit if handled by the end of the current turn', function(done){
+      var rejectionCount = 0;
+      var reason = new Error('Rejection Reason');
+
+      RSVP.on('error', function(event){
+        assert(false, 'should not have errored');
+        done();
+      });
+
+      var promise = RSVP.Promise.reject(reason);
+      RSVP.Promise.resolve().then(function() {
+        promise.catch(function() {
+          done();
+        });
+      });
+    });
+
   });
 
   describe("RSVP.resolve", function(){
@@ -1861,29 +1867,6 @@ describe("RSVP extensions", function() {
         });
 
         var promise = RSVP.reject(reason);
-      });
-    });
-
-    describe('error', function() {
-      afterEach(function() {
-        RSVP.off('error');
-      });
-
-      specify('does not emit if handled by the end of the current turn', function(done){
-        var rejectionCount = 0;
-        var reason = new Error('Rejection Reason');
-
-        RSVP.on('error', function(event){
-          assert(false, 'should not have errored');
-          done();
-        });
-
-        var promise = RSVP.Promise.reject(reason);
-        RSVP.Promise.resolve().then(function() {
-          promise.catch(function() {
-            done();
-          });
-        });
       });
     });
 


### PR DESCRIPTION
Fixes the tests.

Which leaves: "investigate a better solution that still works with the built-in async and pluggable async mechanisms (that doesn't bloat file size)".  What's the problem with the current solution?
