### PR TITLE
[fixes #330] “works” in Nashorn

### DIFF
--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -1,4 +1,5 @@
 var len = 0;
+var toString = {}.toString;
 
 export default function asap(callback, arg) {
   queue[len] = callback;
@@ -28,10 +29,25 @@ function useNextTick() {
   };
 }
 
+// nashorn
+function usePhasedTimer() {
+  var t = new (Java.type('java.util.Timer'));
+  var p = new (Java.type('java.util.concurrent.Phaser'));
+
+  return function(fn) {
+    p.bulkRegister(2);
+    t.schedule(function() {
+      p.awaitAdvance(p.arriveAndDeregister());
+      fn && fn() || flush();
+    }, 0);
+    p.arriveAndDeregister();
+  };
+}
+
 // vertx
-function useVertxTimer() {
+function useVertxTimer(fn) {
   return function() {
-    vertxNext(flush);
+    vertxNext(fn || flush);
   };
 }
 
@@ -56,8 +72,8 @@ function useMessageChannel() {
 }
 
 function useSetTimeout() {
-  return function() {
-    setTimeout(flush, 1);
+  return function(fn) {
+    setTimeout(fn || flush, 1);
   };
 }
 
@@ -86,16 +102,24 @@ function attemptVertex() {
   }
 }
 
+var _schedule;
+if (typeof Java !== 'undefined' && toString.call(Java)) {
+  _schedule = usePhasedTimer();
+} else if (browserWindow === undefined && typeof require === 'function') {
+  _schedule = attemptVertex();
+} else {
+  _schedule = useSetTimeout();
+}
+
+export var schedule = _schedule;
 var scheduleFlush;
 // Decide what async method to use to triggering processing of queued callbacks:
-if (typeof process !== 'undefined' && {}.toString.call(process) === '[object process]') {
+if (typeof process !== 'undefined' && toString.call(process) === '[object process]') {
   scheduleFlush = useNextTick();
 } else if (BrowserMutationObserver) {
   scheduleFlush = useMutationObserver();
 } else if (isWorker) {
   scheduleFlush = useMessageChannel();
-} else if (browserWindow === undefined && typeof require === 'function') {
-  scheduleFlush = attemptVertex();
 } else {
-  scheduleFlush = useSetTimeout();
+  scheduleFlush = _schedule;
 }

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -1,4 +1,5 @@
 import { config } from './config';
+import { schedule } from './asap';
 import instrument from './instrument';
 
 import {
@@ -172,11 +173,11 @@ Promise.prototype = {
 
   _onError: function (reason) {
     config.async(function(promise) {
-      setTimeout(function() {
+      schedule(function() {
         if (promise._onError) {
           config['trigger']('error', reason);
         }
-      }, 0);
+      });
     }, this);
   },
 


### PR DESCRIPTION
NOTE: as Nashorn has real threads, it does not have the same
run-to-completion guarentee as the JavaScript you may be familiar with.
As such if you are not extremely careful in how you use these threads
you will easily put browser/node JavaScript libraries in a bad state.
RSVP included.

It would be fun to fork RSVP and ensure it’s thread safety in such
environments, but as no other environment has these requirements it not
likely not happen any time soon.
- also fix `RSVP.on(‘error’,` on vertex

Also, the test suite itself does not yet run in Nashorn so only some
manual testing “proved” it would work. I have relatively good confidence
in this, but at some point soon it would be better to get the test suite
running on Nashorn. I do suspect it will likely be a sizable investment.
- [ ] actually think if this is even sufficient
- [ ] try to get some tests working.
