### PR TITLE
Problem with path for vertx.js for browserify v7.0.2.

### DIFF
--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -86,7 +86,8 @@ function flush() {
 
 function attemptVertex() {
   try {
-    var vertx = require('../vertx');
+    var r = require;
+    var vertx = r('vertx');
     var vertxNext = vertx.runOnLoop || vertx.runOnContext;
     return useVertxTimer();
   } catch(e) {


### PR DESCRIPTION
Browserify wants to load file from 'dist' folder, but vertx.js is in the root folder.
