### PR TITLE
[BUGFIX release] use more supported version of export default

### DIFF
--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -27,7 +27,7 @@ export function makeSettledResult(state, position, value) {
   }
 }
 
-export default function Enumerator(Constructor, input, abortOnReject, label) {
+function Enumerator(Constructor, input, abortOnReject, label) {
   this._instanceConstructor = Constructor;
   this.promise = new Constructor(noop, label);
   this._abortOnReject = abortOnReject;
@@ -52,6 +52,8 @@ export default function Enumerator(Constructor, input, abortOnReject, label) {
     reject(this.promise, this._validationError());
   }
 }
+
+export default Enumerator;
 
 Enumerator.prototype._validateInput = function(input) {
   return isArray(input);

--- a/lib/rsvp/promise-hash.js
+++ b/lib/rsvp/promise-hash.js
@@ -6,9 +6,11 @@ import {
   o_create
 } from './utils';
 
-export default function PromiseHash(Constructor, object, label) {
+function PromiseHash(Constructor, object, label) {
   this._superConstructor(Constructor, object, true, label);
 }
+
+export default PromiseHash;
 
 PromiseHash.prototype = o_create(Enumerator.prototype);
 PromiseHash.prototype._superConstructor = Enumerator;

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -135,7 +135,7 @@ function needsNew() {
   Useful for tooling.
   @constructor
 */
-export default function Promise(resolver, label) {
+function Promise(resolver, label) {
   this._id = counter++;
   this._label = label;
   this._state = undefined;
@@ -158,6 +158,8 @@ export default function Promise(resolver, label) {
     initializePromise(this, resolver);
   }
 }
+
+export default Promise;
 
 Promise.cast = Resolve; // deprecated
 Promise.all = all;


### PR DESCRIPTION
The old es6 module transpiler does not support
`export default function whatever` syntax. This
is what some downstream libraries like Ember use.

Essentially reverts
6bd655a72a6d72f26fc69611dbe43cac6bb8c944.

refs emberjs/ember.js#9939
