### PR TITLE
main file should point at an actual file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Stefan Penner <stefan.penner@gmail.com>"
   ],
   "description": "A lightweight library that provides tools for organizing asynchronous code",
-  "main": "dist/rsvp.js",
+  "main": "rsvp.js",
   "keywords": [
     "promise"
   ],


### PR DESCRIPTION
While installing https://github.com/eviltrout/ember-performance I ran into some code that explicitly looks to the `main` file as defined in `bower.json`. It turns out `bower.json` still point at `dist/` despite the [components bower repo](https://github.com/components/rsvp.js) having no `dist/` directory.

Fixes the `main` path to point as a real file.