### PR TITLE
Support objects not inheriting from Object.prototype in RSVP.hash()

### DIFF
--- a/lib/rsvp/promise-hash.js
+++ b/lib/rsvp/promise-hash.js
@@ -32,7 +32,7 @@ PromiseHash.prototype._enumerate = function() {
   var results = [];
 
   for (var key in input) {
-    if (promise._state === PENDING && input.hasOwnProperty(key)) {
+    if (promise._state === PENDING && Object.prototype.hasOwnProperty.call(input, key)) {
       results.push({
         position: key,
         entry: input[key]

--- a/test/extension-test.js
+++ b/test/extension-test.js
@@ -726,6 +726,15 @@ describe("RSVP extensions", function() {
       });
     });
 
+    specify('works with an object that does not inherit from Object.prototype', function(done) {
+      var hash = Object.create(null)
+      hash.someValue = Promise.resolve('hello')
+      RSVP.hash(hash).then(function(results) {
+        assert(objectEquals(results, { someValue: 'hello' }));
+        done();
+      });
+    });
+
   });
 
   describe("RSVP.hashSettled", function() {


### PR DESCRIPTION
Avoids this:
``` JavaScript
var object = Object.create(null)
RSVP.hash(object) // Fail :)
```