### PR TITLE
Fix typo issue - Replace 'is' by 'it'

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ getJSON("/post/1.json").then(function(post) {
 ## Error Handling
 
 There are times when dealing with promises that it seems like any errors
-are being 'swallowed', and not properly raised. This makes is extremely
+are being 'swallowed', and not properly raised. This makes it extremely
 difficult to track down where a given issue is coming from. Thankfully,
 `RSVP` has a solution for this problem built in.
 


### PR DESCRIPTION
I noticed there was a typo issue, there's the fix :+1: 