### PR TITLE
Properly detect if the environment is Node

### DIFF
--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -16,7 +16,8 @@ export default function asap(callback, arg) {
 var browserWindow = (typeof window !== 'undefined') ? window : undefined;
 var browserGlobal = browserWindow || {};
 var BrowserMutationObserver = browserGlobal.MutationObserver || browserGlobal.WebKitMutationObserver;
-var isNode = typeof process !== 'undefined' && {}.toString.call(process) === '[object process]';
+var isNode = typeof window === 'undefined' &&
+  typeof process !== 'undefined' && {}.toString.call(process) === '[object process]';
 
 // test for web worker but not in IE10
 var isWorker = typeof Uint8ClampedArray !== 'undefined' &&


### PR DESCRIPTION
This fixes how we currently determine if the running environment is Node, by also ensuring that `window` is not defined. Simply checking for `process` is insufficient in browser environments such as those provided by [NW.js](http://nwjs.io/) or [Electron](http://electron.atom.io/), which also define a `window.process`.

This issue is related to this [PR](https://github.com/emberjs/ember.js/pull/11895) in Ember.