### PR TITLE
Correctly set `isNode` flag when running in NW.js, but in Node's context

### DIFF
--- a/lib/rsvp/asap.js
+++ b/lib/rsvp/asap.js
@@ -16,7 +16,7 @@ export default function asap(callback, arg) {
 var browserWindow = (typeof window !== 'undefined') ? window : undefined;
 var browserGlobal = browserWindow || {};
 var BrowserMutationObserver = browserGlobal.MutationObserver || browserGlobal.WebKitMutationObserver;
-var isNode = typeof window === 'undefined' &&
+var isNode = typeof self === 'undefined' &&
   typeof process !== 'undefined' && {}.toString.call(process) === '[object process]';
 
 // test for web worker but not in IE10


### PR DESCRIPTION
In NW.js, you can either execute code in the browser context, or in Node's context. Setting `isNode` to true when `process` exists but `window` is undefined is incorrect because NW.js exposes `window` in Node as well. We need to check for `self` instead.

References #398