### PR TITLE
Add jsnext:main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "3.1.0",
   "description": "A lightweight library that provides tools for organizing asynchronous code",
   "main": "dist/rsvp.js",
+  "jsnext:main":"lib/rsvp.js",
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
Since rsvp.js is already organized with ES6 modules and distributed as an UMD package. With `jsnext:main` field introduced, some ES6-aware bundlers (such as rollup, webpack2) can take advantages of it to do tree-shaking.

Here is a discussion related: https://github.com/jsforum/jsforum/issues/5. The field name is ambiguity and    may be changed. However it will be helpful if landed.