### PR TITLE
[FIXES #271] detect + de-opt for then/constructor.resolve tampering

### DIFF
--- a/lib/rsvp/-internal.js
+++ b/lib/rsvp/-internal.js
@@ -99,12 +99,11 @@ function handleMaybeThenable(promise, maybeThenable, then) {
   }
 }
 
-function resolve(promise, value, _then) {
-  // TODO: handle this branching at the leaves...
+function resolve(promise, value) {
   if (promise === value) {
     fulfill(promise, value);
-  } else if (_then || objectOrFunction(value)) {
-    handleMaybeThenable(promise, value, _then || getThen(value));
+  } else if (objectOrFunction(value)) {
+    handleMaybeThenable(promise, value, getThen(value));
   } else {
     fulfill(promise, value);
   }
@@ -224,7 +223,7 @@ function invokeCallback(settled, promise, callback, detail) {
   if (promise._state !== PENDING) {
     // noop
   } else if (hasCallback && succeeded) {
-    resolve(promise, value, undefined);
+    resolve(promise, value);
   } else if (failed) {
     reject(promise, error);
   } else if (settled === FULFILLED) {
@@ -264,5 +263,6 @@ export {
   FULFILLED,
   REJECTED,
   PENDING,
-  getThen
+  getThen,
+  handleMaybeThenable
 };

--- a/lib/rsvp/-internal.js
+++ b/lib/rsvp/-internal.js
@@ -2,11 +2,12 @@ import {
   objectOrFunction,
   isFunction
 } from './utils';
-
+import originalThen from './then';
+import originalResolve from './promise/resolve';
 import instrument from './instrument';
 
 import { config } from './config';
-
+import Promise from './promise';
 function  withOwnPromise() {
   return new TypeError('A promises callback cannot return that same promise.');
 }
@@ -81,11 +82,13 @@ function handleOwnThenable(promise, thenable) {
 }
 
 function handleMaybeThenable(promise, maybeThenable) {
-  if (maybeThenable.constructor === promise.constructor) {
+  var then = getThen(maybeThenable);
+
+  if (maybeThenable.constructor === promise.constructor &&
+      then === originalThen &&
+      constructor.resolve === originalResolve) {
     handleOwnThenable(promise, maybeThenable);
   } else {
-    var then = getThen(maybeThenable);
-
     if (then === GET_THEN_ERROR) {
       reject(promise, GET_THEN_ERROR.error);
     } else if (then === undefined) {

--- a/lib/rsvp/-internal.js
+++ b/lib/rsvp/-internal.js
@@ -44,7 +44,7 @@ function handleForeignThenable(promise, thenable, then) {
       if (sealed) { return; }
       sealed = true;
       if (thenable !== value) {
-        resolve(promise, value);
+        resolve(promise, value, undefined);
       } else {
         fulfill(promise, value);
       }
@@ -71,7 +71,7 @@ function handleOwnThenable(promise, thenable) {
   } else {
     subscribe(thenable, undefined, function(value) {
       if (thenable !== value) {
-        resolve(promise, value);
+        resolve(promise, value, undefined);
       } else {
         fulfill(promise, value);
       }
@@ -81,9 +81,7 @@ function handleOwnThenable(promise, thenable) {
   }
 }
 
-function handleMaybeThenable(promise, maybeThenable) {
-  var then = getThen(maybeThenable);
-
+function handleMaybeThenable(promise, maybeThenable, then) {
   if (maybeThenable.constructor === promise.constructor &&
       then === originalThen &&
       constructor.resolve === originalResolve) {
@@ -101,11 +99,12 @@ function handleMaybeThenable(promise, maybeThenable) {
   }
 }
 
-function resolve(promise, value) {
+function resolve(promise, value, _then) {
+  // TODO: handle this branching at the leaves...
   if (promise === value) {
     fulfill(promise, value);
-  } else if (objectOrFunction(value)) {
-    handleMaybeThenable(promise, value);
+  } else if (_then || objectOrFunction(value)) {
+    handleMaybeThenable(promise, value, _then || getThen(value));
   } else {
     fulfill(promise, value);
   }
@@ -225,7 +224,11 @@ function invokeCallback(settled, promise, callback, detail) {
   if (promise._state !== PENDING) {
     // noop
   } else if (hasCallback && succeeded) {
-    resolve(promise, value);
+    if (value && typeof value === 'object') {
+      handleMaybeThenable(promise, value, getThen(value));
+    } else {
+      resolve(promise, value, undefined);
+    }
   } else if (failed) {
     reject(promise, error);
   } else if (settled === FULFILLED) {
@@ -264,5 +267,6 @@ export {
   invokeCallback,
   FULFILLED,
   REJECTED,
-  PENDING
+  PENDING,
+  getThen
 };

--- a/lib/rsvp/-internal.js
+++ b/lib/rsvp/-internal.js
@@ -224,11 +224,7 @@ function invokeCallback(settled, promise, callback, detail) {
   if (promise._state !== PENDING) {
     // noop
   } else if (hasCallback && succeeded) {
-    if (value && typeof value === 'object') {
-      handleMaybeThenable(promise, value, getThen(value));
-    } else {
-      resolve(promise, value, undefined);
-    }
+    resolve(promise, value, undefined);
   } else if (failed) {
     reject(promise, error);
   } else if (settled === FULFILLED) {

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -13,6 +13,9 @@ import {
   PENDING
 } from './-internal';
 
+import originalThen from './then';
+import originalResolve from './promise/resolve';
+
 export function makeSettledResult(state, position, value) {
   if (state === FULFILLED) {
     return {
@@ -84,7 +87,10 @@ Enumerator.prototype._eachEntry = function(entry, i) {
   var enumerator = this;
   var c = enumerator._instanceConstructor;
   if (isMaybeThenable(entry)) {
-    if (entry.constructor === c && entry._state !== PENDING) {
+    if (entry.constructor === c &&
+        entry.then === originalThen && /* TODO: ilegal then access */
+        c.resolve === originalResolve &&
+        entry._state !== PENDING) {
       entry._onError = null;
       enumerator._settledAt(entry._state, i, entry._result);
     } else {

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -35,30 +35,28 @@ export function makeSettledResult(state, position, value) {
 }
 
 function Enumerator(Constructor, input, abortOnReject, label) {
-  var enumerator = this;
+  this._instanceConstructor = Constructor;
+  this.promise = new Constructor(noop, label);
+  this._abortOnReject = abortOnReject;
 
-  enumerator._instanceConstructor = Constructor;
-  enumerator.promise = new Constructor(noop, label);
-  enumerator._abortOnReject = abortOnReject;
+  if (this._validateInput(input)) {
+    this._input     = input;
+    this.length     = input.length;
+    this._remaining = input.length;
 
-  if (enumerator._validateInput(input)) {
-    enumerator._input     = input;
-    enumerator.length     = input.length;
-    enumerator._remaining = input.length;
+    this._init();
 
-    enumerator._init();
-
-    if (enumerator.length === 0) {
-      fulfill(enumerator.promise, enumerator._result);
+    if (this.length === 0) {
+      fulfill(this.promise, this._result);
     } else {
-      enumerator.length = enumerator.length || 0;
-      enumerator._enumerate();
-      if (enumerator._remaining === 0) {
-        fulfill(enumerator.promise, enumerator._result);
+      this.length = this.length || 0;
+      this._enumerate();
+      if (this._remaining === 0) {
+        fulfill(this.promise, this._result);
       }
     }
   } else {
-    reject(enumerator.promise, enumerator._validationError());
+    reject(this.promise, this._validationError());
   }
 }
 
@@ -77,62 +75,65 @@ Enumerator.prototype._init = function() {
 };
 
 Enumerator.prototype._enumerate = function() {
-  var enumerator = this;
-  var length     = enumerator.length;
-  var promise    = enumerator.promise;
-  var input      = enumerator._input;
+  var length     = this.length;
+  var promise    = this.promise;
+  var input      = this._input;
 
   for (var i = 0; promise._state === PENDING && i < length; i++) {
-    enumerator._eachEntry(input[i], i);
+    this._eachEntry(input[i], i);
+  }
+};
+
+Enumerator.prototype._settleMaybeThenable = function(entry, i) {
+  var c = this._instanceConstructor;
+  var resolve = c.resolve;
+
+  if (resolve === originalResolve) {
+    var then = getThen(entry);
+
+    if (then === originalThen &&
+        entry._state !== PENDING) {
+      entry._onError = null;
+      this._settledAt(entry._state, i, entry._result);
+    } else if (typeof then !== 'function') {
+      this._remaining--;
+      this._result[i] = this._makeResult(FULFILLED, i, entry);
+    } else if (c === Promise) {
+      var promise = new c(noop);
+      handleMaybeThenable(promise, entry, then);
+      this._willSettleAt(promise, i);
+    } else {
+      this._willSettleAt(new c(function(resolve) { resolve(entry); }), i);
+    }
+  } else {
+    this._willSettleAt(resolve(entry), i);
   }
 };
 
 Enumerator.prototype._eachEntry = function(entry, i) {
-  var enumerator = this;
-  var c = enumerator._instanceConstructor;
-  var resolve = c.resolve;
   if (isMaybeThenable(entry)) {
-    if (resolve === originalResolve) {
-      var then = getThen(entry);
-
-      if (then === originalThen &&
-          entry._state !== PENDING) {
-          entry._onError = null;
-          enumerator._settledAt(entry._state, i, entry._result);
-      } else if (typeof then !== 'function') {
-        enumerator._result[i] = enumerator._makeResult(FULFILLED, i, entry);
-      } else if (c === Promise) {
-        var promise = new c(noop);
-        handleMaybeThenable(promise, entry, then);
-        enumerator._willSettleAt(promise, i);
-      } else {
-        enumerator._willSettleAt(new c(function(resolve) { resolve(entry); }), i);
-      }
-    } else {
-      enumerator._willSettleAt(resolve(entry), i);
-    }
+    this._settleMaybeThenable(entry, i);
   } else {
-    enumerator._remaining--;
-    enumerator._result[i] = enumerator._makeResult(FULFILLED, i, entry);
+    this._remaining--;
+    this._result[i] = this._makeResult(FULFILLED, i, entry);
   }
 };
 
 Enumerator.prototype._settledAt = function(state, i, value) {
-  var enumerator = this;
-  var promise = enumerator.promise;
+  var promise = this.promise;
 
   if (promise._state === PENDING) {
-    enumerator._remaining--;
+    this._remaining--;
 
-    if (enumerator._abortOnReject && state === REJECTED) {
+    if (this._abortOnReject && state === REJECTED) {
       reject(promise, value);
     } else {
-      enumerator._result[i] = enumerator._makeResult(state, i, value);
+      this._result[i] = this._makeResult(state, i, value);
     }
   }
 
-  if (enumerator._remaining === 0) {
-    fulfill(promise, enumerator._result);
+  if (this._remaining === 0) {
+    fulfill(promise, this._result);
   }
 };
 

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -90,8 +90,9 @@ Enumerator.prototype._enumerate = function() {
 Enumerator.prototype._eachEntry = function(entry, i) {
   var enumerator = this;
   var c = enumerator._instanceConstructor;
+  var resolve = c.resolve;
   if (isMaybeThenable(entry)) {
-    if (c.resolve === originalResolve) {
+    if (resolve === originalResolve) {
       var then = getThen(entry);
 
       if (then === originalThen &&
@@ -105,10 +106,10 @@ Enumerator.prototype._eachEntry = function(entry, i) {
         handleMaybeThenable(promise, entry, then);
         enumerator._willSettleAt(promise, i);
       } else {
-        enumerator._willSettleAt(c.resolve(entry), i);
+        enumerator._willSettleAt(resolve(entry), i);
       }
     } else {
-      enumerator._willSettleAt(c.resolve(entry), i);
+      enumerator._willSettleAt(resolve(entry), i);
     }
   } else {
     enumerator._remaining--;

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -90,7 +90,7 @@ Enumerator.prototype._eachEntry = function(entry, i) {
   var enumerator = this;
   var c = enumerator._instanceConstructor;
   if (isMaybeThenable(entry)) {
-    if (c.resolve === originalResolve && c === Promise) {
+    if (c.resolve === originalResolve) {
       var then = getThen(entry);
 
       if (then === originalThen &&
@@ -99,10 +99,12 @@ Enumerator.prototype._eachEntry = function(entry, i) {
           enumerator._settledAt(entry._state, i, entry._result);
       } else if (typeof then !== 'function') {
         enumerator._result[i] = enumerator._makeResult(FULFILLED, i, entry);
-      } else {
+      } else if (c === Promise) {
         var promise = new c(noop);
         resolve(promise, entry, then);
         enumerator._willSettleAt(promise, i);
+      } else {
+        enumerator._willSettleAt(c.resolve(entry), i);
       }
     } else {
       enumerator._willSettleAt(c.resolve(entry), i);

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -106,8 +106,7 @@ Enumerator.prototype._eachEntry = function(entry, i) {
         handleMaybeThenable(promise, entry, then);
         enumerator._willSettleAt(promise, i);
       } else {
-        // this path invokes `then` twice
-        enumerator._willSettleAt(resolve(entry), i);
+        enumerator._willSettleAt(new c(function(resolve) { resolve(entry); }), i);
       }
     } else {
       enumerator._willSettleAt(resolve(entry), i);

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -6,6 +6,7 @@ import {
 import {
   noop,
   resolve,
+  handleMaybeThenable,
   reject,
   fulfill,
   subscribe,
@@ -101,7 +102,7 @@ Enumerator.prototype._eachEntry = function(entry, i) {
         enumerator._result[i] = enumerator._makeResult(FULFILLED, i, entry);
       } else if (c === Promise) {
         var promise = new c(noop);
-        resolve(promise, entry, then);
+        handleMaybeThenable(promise, entry, then);
         enumerator._willSettleAt(promise, i);
       } else {
         enumerator._willSettleAt(c.resolve(entry), i);

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -106,6 +106,7 @@ Enumerator.prototype._eachEntry = function(entry, i) {
         handleMaybeThenable(promise, entry, then);
         enumerator._willSettleAt(promise, i);
       } else {
+        // this path invokes `then` twice
         enumerator._willSettleAt(resolve(entry), i);
       }
     } else {

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -5,14 +5,17 @@ import {
 
 import {
   noop,
+  resolve,
   reject,
   fulfill,
   subscribe,
   FULFILLED,
   REJECTED,
-  PENDING
+  PENDING,
+  getThen
 } from './-internal';
 
+import Promise from './promise';
 import originalThen from './then';
 import originalResolve from './promise/resolve';
 
@@ -87,12 +90,20 @@ Enumerator.prototype._eachEntry = function(entry, i) {
   var enumerator = this;
   var c = enumerator._instanceConstructor;
   if (isMaybeThenable(entry)) {
-    if (entry.constructor === c &&
-        entry.then === originalThen && /* TODO: ilegal then access */
-        c.resolve === originalResolve &&
-        entry._state !== PENDING) {
-      entry._onError = null;
-      enumerator._settledAt(entry._state, i, entry._result);
+    if (c.resolve === originalResolve && c === Promise) {
+      var then = getThen(entry);
+
+      if (then === originalThen &&
+          entry._state !== PENDING) {
+          entry._onError = null;
+          enumerator._settledAt(entry._state, i, entry._result);
+      } else if (typeof then !== 'function') {
+        enumerator._result[i] = enumerator._makeResult(FULFILLED, i, entry);
+      } else {
+        var promise = new c(noop);
+        resolve(promise, entry, then);
+        enumerator._willSettleAt(promise, i);
+      }
     } else {
       enumerator._willSettleAt(c.resolve(entry), i);
     }

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -132,28 +132,17 @@ function needsNew() {
   @constructor
 */
 export default function Promise(resolver, label) {
-  var promise = this;
+  this._id = counter++;
+  this._label = label;
+  this._state = undefined;
+  this._result = undefined;
+  this._subscribers = [];
 
-  promise._id = counter++;
-  promise._label = label;
-  promise._state = undefined;
-  promise._result = undefined;
-  promise._subscribers = [];
-
-  if (config.instrument) {
-    instrument('created', promise);
-  }
+  config.instrument && instrument('created', this);
 
   if (noop !== resolver) {
-    if (!isFunction(resolver)) {
-      needsResolver();
-    }
-
-    if (!(promise instanceof Promise)) {
-      needsNew();
-    }
-
-    initializePromise(promise, resolver);
+    typeof resolver !== 'function' && needsResolver();
+    this instanceof Promise ? initializePromise(this, resolver) : needsNew();
   }
 }
 

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -1,6 +1,6 @@
 import { config } from './config';
 import instrument from './instrument';
-
+import then from './then';
 import {
   isFunction,
   now
@@ -8,11 +8,7 @@ import {
 
 import {
   noop,
-  subscribe,
-  initializePromise,
-  invokeCallback,
-  FULFILLED,
-  REJECTED
+  initializePromise
 } from './-internal';
 
 import all from './promise/all';
@@ -375,37 +371,7 @@ Promise.prototype = {
   Useful for tooling.
   @return {Promise}
 */
-  then: function(onFulfillment, onRejection, label) {
-    var parent = this;
-    var state = parent._state;
-
-    if (state === FULFILLED && !onFulfillment || state === REJECTED && !onRejection) {
-      if (config.instrument) {
-        instrument('chained', parent, parent);
-      }
-      return parent;
-    }
-
-    parent._onError = null;
-
-    var child = new parent.constructor(noop, label);
-    var result = parent._result;
-
-    if (config.instrument) {
-      instrument('chained', parent, child);
-    }
-
-    if (state) {
-      var callback = arguments[state - 1];
-      config.async(function(){
-        invokeCallback(state, child, callback, result);
-      });
-    } else {
-      subscribe(parent, child, onFulfillment, onRejection);
-    }
-
-    return child;
-  },
+  then: then,
 
 /**
   `catch` is simply sugar for `then(undefined, onRejection)` which makes it the same

--- a/lib/rsvp/then.js
+++ b/lib/rsvp/then.js
@@ -1,0 +1,41 @@
+import { config } from './config';
+import instrument from './instrument';
+import {
+  noop,
+  subscribe,
+  FULFILLED,
+  REJECTED,
+  invokeCallback
+} from './-internal';
+
+export default function then(onFulfillment, onRejection, label) {
+  var parent = this;
+  var state = parent._state;
+
+  if (state === FULFILLED && !onFulfillment || state === REJECTED && !onRejection) {
+    if (config.instrument) {
+      instrument('chained', parent, parent);
+    }
+    return parent;
+  }
+
+  parent._onError = null;
+
+  var child = new parent.constructor(noop, label);
+  var result = parent._result;
+
+  if (config.instrument) {
+    instrument('chained', parent, child);
+  }
+
+  if (state) {
+    var callback = arguments[state - 1];
+    config.async(function(){
+      invokeCallback(state, child, callback, result);
+    });
+  } else {
+    subscribe(parent, child, onFulfillment, onRejection);
+  }
+
+  return child;
+}

--- a/lib/rsvp/then.js
+++ b/lib/rsvp/then.js
@@ -13,9 +13,7 @@ export default function then(onFulfillment, onRejection, label) {
   var state = parent._state;
 
   if (state === FULFILLED && !onFulfillment || state === REJECTED && !onRejection) {
-    if (config.instrument) {
-      instrument('chained', parent, parent);
-    }
+    config.instrument && instrument('chained', parent, parent);
     return parent;
   }
 
@@ -24,9 +22,7 @@ export default function then(onFulfillment, onRejection, label) {
   var child = new parent.constructor(noop, label);
   var result = parent._result;
 
-  if (config.instrument) {
-    instrument('chained', parent, child);
-  }
+  config.instrument && instrument('chained', parent, child);
 
   if (state) {
     var callback = arguments[state - 1];

--- a/test/extension-test.js
+++ b/test/extension-test.js
@@ -923,6 +923,15 @@ describe("RSVP extensions", function() {
       ]).then(function(){ done(); });
     });
 
+    it('works with plan pojo input', function(done) {
+      RSVP.Promise.all([
+        {}
+      ]).then(function(result) {
+        assert.deepEqual(result, [{}]);
+        done();
+      });
+    });
+
     specify('fulfilled only after all of the other promises are fulfilled', function(done) {
       var firstResolved, secondResolved, firstResolver, secondResolver;
 


### PR DESCRIPTION
- [x] address extra `then` access in Enumerator, spec only allows one.
- [x] audit for more cases missed.
- [x] run benchmarks
- [x] fixup some perf stuff