### PR TITLE
Fix typos in API docs

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -199,12 +199,12 @@ Promise.prototype = {
   findUser().then(function (user) {
     throw new Error('Found user, but still unhappy');
   }, function (reason) {
-    throw new Error('`findUser` rejected and we're unhappy');
+    throw new Error('`findUser` rejected and we\'re unhappy');
   }).then(function (value) {
     // never reached
   }, function (reason) {
     // if `findUser` fulfilled, `reason` will be 'Found user, but still unhappy'.
-    // If `findUser` rejected, `reason` will be '`findUser` rejected and we're unhappy'.
+    // If `findUser` rejected, `reason` will be '`findUser` rejected and we\'re unhappy'.
   });
   ```
   If the downstream promise does not specify a rejection handler, rejection reasons will be propagated further downstream.
@@ -368,7 +368,7 @@ Promise.prototype = {
 
   ```js
   function findAuthor(){
-    throw new Error('couldn't find that author');
+    throw new Error('couldn\'t find that author');
   }
 
   // synchronous


### PR DESCRIPTION
Escape single quotes (apostrophes) in contractions