### PR TITLE
Update Promise documentation to use RSVP.Promise and RSVP.all

### DIFF
--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -60,7 +60,7 @@ function needsNew() {
   ------------
 
   ```js
-  var promise = new Promise(function(resolve, reject) {
+  var promise = new RSVP.Promise(function(resolve, reject) {
     // on success
     resolve(value);
 
@@ -83,7 +83,7 @@ function needsNew() {
 
   ```js
   function getJSON(url) {
-    return new Promise(function(resolve, reject){
+    return new RSVP.Promise(function(resolve, reject){
       var xhr = new XMLHttpRequest();
 
       xhr.open('GET', url);
@@ -114,7 +114,7 @@ function needsNew() {
   Unlike callbacks, promises are great composable primitives.
 
   ```js
-  Promise.all([
+  RSVP.all([
     getJSON('/posts'),
     getJSON('/comments')
   ]).then(function(values){


### PR DESCRIPTION
This matches the basic usage demonstrated in the README. Also, this should incidentally end up fixing issue emberjs/ember.js#10844. I left out `import RSVP from 'rsvp';` (although that's implied for Ember) because that doesn't work in Node yet without Babel -- but `var RSVP = require('rsvp');` has the same effect.