### PR TITLE
Fix invalid es6.

### DIFF
--- a/lib/rsvp/utils.js
+++ b/lib/rsvp/utils.js
@@ -21,7 +21,7 @@ export let isArray = _isArray;
 
 // Date.now is not available in browsers < IE9
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now#Compatibility
-export let now = Date.now || () => new Date().getTime();
+export let now = Date.now || (() => new Date().getTime());
 
 function F() { }
 


### PR DESCRIPTION
`export let now = Date.now || () => new Date().getTime();` is not valid es6 and
is rejected by acorn (used by rollup) as well as v8.  That it parses in babel is
a bug.

This fixes the build for heimdalljs/heimdalljs-lib and presumably other
libraries that use `rollup-plugin-commonjs` and rsvp.