### PR TITLE
Updates to match Node and Ember's LTS policies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "futures"
   ],
   "author": "Tilde, Inc. & Stefan Penner",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": "0.12.* || 4.* || 6.* || 7.*"
+  }
 }


### PR DESCRIPTION
Specifies versions of Node.js per the LTS WG. Incremental step toward making the Ember ecosystem able to support [engine-strict](https://docs.npmjs.com/misc/config#engine-strict).

(PRs like these will show up when Greenkeeper asks us to bump versions of deps.)
