### PR TITLE
Implements `RSVP.from`

### DIFF
--- a/lib/rsvp/from.js
+++ b/lib/rsvp/from.js
@@ -1,0 +1,24 @@
+import hash from './hash';
+import all from './all';
+
+/**
+  `RSVP.from` wraps the argument passed in a promise.
+
+  It can also optionally receive a label as a second argument.
+
+  @method from
+  @static
+  @for RSVP
+  @param {Array,Object}
+  @param {String} label An optional label. This is useful
+  for tooling.
+*/
+export default function from(object, label) {
+  if (Array.isArray(object)) {
+    return all(object, label);
+  } else if (typeof object == 'object') {
+    return hash(object, label);
+  } else {
+    return Promise.resolve(object, label);
+  }
+}


### PR DESCRIPTION
I'm not actually happy with the name, since the goal here isn't to wrap the value in a promise, but to return a promise that only resolves when all of the inner promises resolves, whether Object, Array, or I guess values.
My suggestion is `RSVP.wait`. I open this discussion to the comments.