### PR TITLE
removed passing constructor

### DIFF
--- a/lib/rsvp/all-settled.js
+++ b/lib/rsvp/all-settled.js
@@ -5,8 +5,8 @@ import {
 import Promise from './promise';
 import { o_create } from './utils';
 
-function AllSettled(Constructor, entries, label) {
-  this._superConstructor(Constructor, entries, false /* don't abort on reject */, label);
+function AllSettled(entries, label) {
+  this._superConstructor(entries, false /* don't abort on reject */, label);
 }
 
 AllSettled.prototype = o_create(Enumerator.prototype);
@@ -69,5 +69,5 @@ AllSettled.prototype._validationError = function() {
 */
 
 export default function allSettled(entries, label) {
-  return new AllSettled(Promise, entries, label).promise;
+  return new AllSettled(entries, label).promise;
 }

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -34,9 +34,8 @@ export function makeSettledResult(state, position, value) {
   }
 }
 
-function Enumerator(Constructor, input, abortOnReject, label) {
-  this._instanceConstructor = Constructor;
-  this.promise = new Constructor(noop, label);
+function Enumerator(input, abortOnReject, label) {
+  this.promise = new Promise(noop, label);
   this._abortOnReject = abortOnReject;
 
   if (this._validateInput(input)) {
@@ -85,8 +84,7 @@ Enumerator.prototype._enumerate = function() {
 };
 
 Enumerator.prototype._settleMaybeThenable = function(entry, i) {
-  let c = this._instanceConstructor;
-  let resolve = c.resolve;
+  let resolve = Promise.resolve;
 
   if (resolve === originalResolve) {
     let then = getThen(entry);
@@ -98,12 +96,10 @@ Enumerator.prototype._settleMaybeThenable = function(entry, i) {
     } else if (typeof then !== 'function') {
       this._remaining--;
       this._result[i] = this._makeResult(FULFILLED, i, entry);
-    } else if (c === Promise) {
-      let promise = new c(noop);
+    } else {
+      let promise = new Promise(noop);
       handleMaybeThenable(promise, entry, then);
       this._willSettleAt(promise, i);
-    } else {
-      this._willSettleAt(new c(resolve => resolve(entry)), i);
     }
   } else {
     this._willSettleAt(resolve(entry), i);

--- a/lib/rsvp/hash-settled.js
+++ b/lib/rsvp/hash-settled.js
@@ -8,8 +8,8 @@ import {
   o_create
 } from './utils';
 
-function HashSettled(Constructor, object, label) {
-  this._superConstructor(Constructor, object, false, label);
+function HashSettled(object, label) {
+  this._superConstructor(object, false, label);
 }
 
 HashSettled.prototype = o_create(PromiseHash.prototype);
@@ -122,5 +122,5 @@ HashSettled.prototype._validationError = function() {
   @static
 */
 export default function hashSettled(object, label) {
-  return new HashSettled(Promise, object, label).promise;
+  return new HashSettled(object, label).promise;
 }

--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -90,5 +90,5 @@ import PromiseHash from './promise-hash';
   have been fulfilled, or rejected if any of them become rejected.
 */
 export default function hash(object, label) {
-  return new PromiseHash(Promise, object, label).promise;
+  return new PromiseHash(object, label).promise;
 }

--- a/lib/rsvp/promise-hash.js
+++ b/lib/rsvp/promise-hash.js
@@ -6,8 +6,8 @@ import {
   o_create
 } from './utils';
 
-function PromiseHash(Constructor, object, label) {
-  this._superConstructor(Constructor, object, true, label);
+function PromiseHash(object, label) {
+  this._superConstructor(object, true, label);
 }
 
 export default PromiseHash;

--- a/lib/rsvp/promise/all.js
+++ b/lib/rsvp/promise/all.js
@@ -48,5 +48,5 @@ import Enumerator from '../enumerator';
   @static
 */
 export default function all(entries, label) {
-  return new Enumerator(this, entries, true /* abort on reject */, label).promise;
+  return new Enumerator(entries, true /* abort on reject */, label).promise;
 }


### PR DESCRIPTION
Couldn't find proper reason why `Constructor` is being passed everywhere within `Enumerator` types, so I removed it :P, free to reject if I am wrong here, thanks