### PR TITLE
cleanup invokeCallback

### DIFF
--- a/lib/rsvp/-internal.js
+++ b/lib/rsvp/-internal.js
@@ -195,40 +195,33 @@ function tryCatch(callback, detail) {
   }
 }
 
-export function invokeCallback(settled, promise, callback, detail) {
-  let hasCallback = isFunction(callback),
-      value, error, succeeded, failed;
+export function invokeCallback(state, promise, callback, detail) {
+  let hasCallback = isFunction(callback);
+  let value, error;
 
   if (hasCallback) {
     value = tryCatch(callback, detail);
 
     if (value === TRY_CATCH_ERROR) {
-      failed = true;
       error = value.error;
       value.error = null; // release
-    } else {
-      succeeded = true;
-    }
-
-    if (promise === value) {
+    } else if (value === promise) {
       reject(promise, withOwnPromise());
       return;
     }
-
   } else {
     value = detail;
-    succeeded = true;
   }
 
   if (promise._state !== PENDING) {
     // noop
-  } else if (hasCallback && succeeded) {
+  } else if (hasCallback && error === undefined) {
     resolve(promise, value);
-  } else if (failed) {
+  } else if (error !== undefined) {
     reject(promise, error);
-  } else if (settled === FULFILLED) {
+  } else if (state === FULFILLED) {
     fulfill(promise, value);
-  } else if (settled === REJECTED) {
+  } else if (state === REJECTED) {
     reject(promise, value);
   }
 }


### PR DESCRIPTION
removed duplicating variables `succeeded, failed` 