### PR TITLE
further cleanup 

### DIFF
--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -16,15 +16,17 @@ import {
   getThen
 } from './-internal';
 
-import Promise from './promise';
+import { default as OriginalPromise } from './promise';
 import originalThen from './then';
-import originalResolve from './promise/resolve';
+import originalResolve from './resolve';
 
 export default class Enumerator {
   constructor(Constructor, input, abortOnReject, label) {
     this._instanceConstructor = Constructor;
     this.promise = new Constructor(noop, label);
     this._abortOnReject = abortOnReject;
+
+    this.isUsingOriginalPromise = Constructor === OriginalPromise;
 
     if (this._validateInput(input)) {
       this.length     = input.length;
@@ -68,9 +70,8 @@ export default class Enumerator {
 
   _settleMaybeThenable(entry, i) {
     let c = this._instanceConstructor;
-    let resolve = c.resolve;
 
-    if (resolve === originalResolve) {
+    if (c.resolve === originalResolve) {
       let then = getThen(entry);
 
       if (then === originalThen && entry._state !== PENDING) {
@@ -79,15 +80,15 @@ export default class Enumerator {
       } else if (typeof then !== 'function') {
         this._remaining--;
         this._result[i] = this._makeResult(FULFILLED, i, entry);
-      } else if (c === Promise) {
+      } else if (this.isUsingOriginalPromise) {
         let promise = new c(noop);
         handleMaybeThenable(promise, entry, then);
         this._willSettleAt(promise, i);
       } else {
-        this._willSettleAt(new c(resolve => resolve(entry)), i);
+        this._willSettleAt(c.resolve(entry), i);
       }
     } else {
-      this._willSettleAt(resolve(entry), i);
+      this._willSettleAt(c.resolve(entry), i);
     }
   }
 

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -16,17 +16,13 @@ import {
   getThen
 } from './-internal';
 
-import { default as OriginalPromise } from './promise';
 import ownThen from './then';
-import ownResolve from './resolve';
 
 export default class Enumerator {
   constructor(Constructor, input, abortOnReject, label) {
     this._instanceConstructor = Constructor;
     this.promise = new Constructor(noop, label);
     this._abortOnReject = abortOnReject;
-
-    this.isUsingOwnPromise = Constructor === OriginalPromise;
 
     if (this._validateInput(input)) {
       this.length     = input.length;
@@ -71,18 +67,13 @@ export default class Enumerator {
   _settleMaybeThenable(entry, i) {
     let c = this._instanceConstructor;
 
-    if (c.resolve === ownResolve) {
-      let then = getThen(entry);
-
-      if (then === ownThen && entry._state !== PENDING) {
-        entry._onError = null;
-        this._settledAt(entry._state, i, entry._result);
-      } else if (typeof then !== 'function') {
-        this._remaining--;
-        this._result[i] = this._makeResult(FULFILLED, i, entry);
-      } else {
-        this._willSettleAt(c.resolve(entry), i);
-      }
+    let then = getThen(entry);
+    if (then === ownThen && entry._state !== PENDING) {
+      entry._onError = null;
+      this._settledAt(entry._state, i, entry._result);
+    } else if (typeof then !== 'function') {
+      this._remaining--;
+      this._result[i] = this._makeResult(FULFILLED, i, entry);
     } else {
       this._willSettleAt(c.resolve(entry), i);
     }

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -80,10 +80,6 @@ export default class Enumerator {
       } else if (typeof then !== 'function') {
         this._remaining--;
         this._result[i] = this._makeResult(FULFILLED, i, entry);
-      } else if (this.isUsingOwnPromise) {
-        let promise = new c(noop);
-        handleMaybeThenable(promise, entry, then);
-        this._willSettleAt(promise, i);
       } else {
         this._willSettleAt(c.resolve(entry), i);
       }

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -17,8 +17,8 @@ import {
 } from './-internal';
 
 import { default as OriginalPromise } from './promise';
-import originalThen from './then';
-import originalResolve from './resolve';
+import ownThen from './then';
+import ownResolve from './resolve';
 
 export default class Enumerator {
   constructor(Constructor, input, abortOnReject, label) {
@@ -26,7 +26,7 @@ export default class Enumerator {
     this.promise = new Constructor(noop, label);
     this._abortOnReject = abortOnReject;
 
-    this.isUsingOriginalPromise = Constructor === OriginalPromise;
+    this.isUsingOwnPromise = Constructor === OriginalPromise;
 
     if (this._validateInput(input)) {
       this.length     = input.length;
@@ -71,16 +71,16 @@ export default class Enumerator {
   _settleMaybeThenable(entry, i) {
     let c = this._instanceConstructor;
 
-    if (c.resolve === originalResolve) {
+    if (c.resolve === ownResolve) {
       let then = getThen(entry);
 
-      if (then === originalThen && entry._state !== PENDING) {
+      if (then === ownThen && entry._state !== PENDING) {
         entry._onError = null;
         this._settledAt(entry._state, i, entry._result);
       } else if (typeof then !== 'function') {
         this._remaining--;
         this._result[i] = this._makeResult(FULFILLED, i, entry);
-      } else if (this.isUsingOriginalPromise) {
+      } else if (this.isUsingOwnPromise) {
         let promise = new c(noop);
         handleMaybeThenable(promise, entry, then);
         this._willSettleAt(promise, i);

--- a/test/extension-test.js
+++ b/test/extension-test.js
@@ -52,7 +52,7 @@ describe('tampering', function() {
       });
     });
 
-  it('tampered resolved', function() {
+    it('tampered resolved', function() {
       var one = RSVP.Promise.resolve(1);
       var two = RSVP.Promise.resolve(2);
       var thenCalled = 0;
@@ -82,8 +82,8 @@ describe('tampering', function() {
         };
 
         return RSVP.Promise.all([two]).then(function(value) {
-          assert.equal(resolveCalled, 1);
-          assert.deepEqual(value, [2]);
+          assert.equal(resolveCalled, 1, 'expected then to be called once');
+          assert.equal(value, 2, 'expected fulfillment value to be 2');
         });
       });
 
@@ -97,8 +97,8 @@ describe('tampering', function() {
         };
 
         return RSVP.Promise.all([two]).then(function(value) {
-          assert.equal(thenCalled, 1);
-          assert.deepEqual(value, [2]);
+          assert.equal(thenCalled, 1, 'expected then to be called once');
+          assert.equal(value, 2, 'expected fulfillment value to be 2');
         });
       });
     });


### PR DESCRIPTION
should be merged after #469 

removed `c.resolve === ownResolve` as it was made probably to
pass tampering test since we are calling `Promise.resolve`
tampering test pass