### PR TITLE
moved all initialization to init

### DIFF
--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -27,19 +27,7 @@ export default class Enumerator {
     this._abortOnReject = abortOnReject;
 
     if (this._validateInput(input)) {
-      this.length     = input.length;
-      this._remaining = input.length;
-
-      this._init();
-
-      if (this.length === 0) {
-        fulfill(this.promise, this._result);
-      } else {
-        this._enumerate(input);
-        if (this._remaining === 0) {
-          fulfill(this.promise, this._result);
-        }
-      }
+      this._init(...arguments);
     } else {
       reject(this.promise, this._validationError());
     }
@@ -53,8 +41,16 @@ export default class Enumerator {
     return new Error('Array Methods must be provided an Array');
   }
 
-  _init() {
-    this._result = new Array(this.length);
+  _init(Constructor, input) {
+    let len = input.length || 0;
+    this.length     = len;
+    this._remaining = len;
+    this._result = new Array(len);
+
+    this._enumerate(input);
+    if (this._remaining === 0) {
+      fulfill(this.promise, this._result);
+    }
   }
 
   _enumerate(input) {

--- a/lib/rsvp/promise-hash.js
+++ b/lib/rsvp/promise-hash.js
@@ -1,7 +1,8 @@
 import Enumerator from './enumerator';
 import {
   PENDING,
-  FULFILLED
+  FULFILLED,
+  fulfill
 } from './-internal';
 
 export default class PromiseHash extends Enumerator {
@@ -9,8 +10,13 @@ export default class PromiseHash extends Enumerator {
     super(Constructor, object, abortOnReject, label);
   }
 
-  _init() {
+  _init(Constructor, object) {
     this._result = {};
+
+    this._enumerate(object);
+    if (this._remaining === 0) {
+      fulfill(this.promise, this._result);
+    }
   }
 
   _validateInput(input) {


### PR DESCRIPTION
motivated by not being able to pass/assign property before calling `super()` (which is needed for #456  where I pass map/filter func)
e.g.

following is not allowed: 
```
class MapEnum extends Enum {
   constructor(Constructor, input, abortOnReject, mapFn, label) {
     this.mapFn = mapFn
     super(...arguments);
  }
}
```
so with this refactor I can do inside init 

```
init(Constructor, input, abortOnReject, label, mapFn) {
     this.mapFn = mapFn
     ....
}
```

Also keeps things consistent as all initialization things are in `init`