### PR TITLE
remove `es5` fallback

### DIFF
--- a/lib/rsvp/all-settled.js
+++ b/lib/rsvp/all-settled.js
@@ -3,7 +3,6 @@ import {
   makeSettledResult
 } from './enumerator';
 import Promise from './promise';
-import { isArray } from './utils';
 
 class AllSettled extends Enumerator {
   constructor(Constructor, entries, label) {
@@ -66,7 +65,7 @@ AllSettled.prototype._makeResult = makeSettledResult;
   */
 
 export default function allSettled(entries, label) {
-  if (!isArray(entries)) {
+  if (!Array.isArray(entries)) {
     return Promise.reject(new TypeError("Promise.allSettled must be called with an array"), label);
   }
 

--- a/lib/rsvp/enumerator.js
+++ b/lib/rsvp/enumerator.js
@@ -1,5 +1,4 @@
 import {
-  isArray,
   isMaybeThenable
 } from './utils';
 

--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -1,10 +1,3 @@
-function indexOf(callbacks, callback) {
-  for (let i=0, l=callbacks.length; i<l; i++) {
-    if (callbacks[i] === callback) { return i; }
-  }
-
-  return -1;
-}
 
 function callbacksFor(object) {
   let callbacks = object._promiseCallbacks;
@@ -101,7 +94,7 @@ export default {
       callbacks = allCallbacks[eventName] = [];
     }
 
-    if (indexOf(callbacks, callback) === -1) {
+    if (callbacks.indexOf(callback)) {
       callbacks.push(callback);
     }
   },
@@ -155,7 +148,7 @@ export default {
 
     callbacks = allCallbacks[eventName];
 
-    index = indexOf(callbacks, callback);
+    index = callbacks.indexOf(callback);
 
     if (index !== -1) { callbacks.splice(index, 1); }
   },

--- a/lib/rsvp/filter.js
+++ b/lib/rsvp/filter.js
@@ -1,7 +1,6 @@
 import Promise from './promise';
 import {
   isFunction,
-  isArray,
   isObject
 } from './utils';
 
@@ -102,7 +101,7 @@ function resolveSingle(promise, label) {
 }
 
 export default function filter(promises, filterFn, label) {
-  if (!isArray(promises) && !(isObject(promises) && promises.then !== undefined )) {
+  if (!Array.isArray(promises) && !(isObject(promises) && promises.then !== undefined )) {
     return Promise.reject(new TypeError("RSVP.filter must be called with an array or promise"), label);
   }
 
@@ -110,7 +109,7 @@ export default function filter(promises, filterFn, label) {
     return Promise.reject(new TypeError("RSVP.filter expects function as a second argument"), label);
   }
 
-  let promise = isArray(promises) ? resolveAll(promises, label) : resolveSingle(promises, label);
+  let promise = Array.isArray(promises) ? resolveAll(promises, label) : resolveSingle(promises, label);
   return promise.then(values => {
     let length = values.length;
     let filtered = new Array(length);

--- a/lib/rsvp/instrument.js
+++ b/lib/rsvp/instrument.js
@@ -32,7 +32,7 @@ export default function instrument(eventName, promise, child) {
       detail: promise._result,
       childId: child && child._id,
       label: promise._label,
-      timeStamp: now(),
+      timeStamp: Date.now(),
       error: config["instrument-with-stack"] ? new Error(promise._label) : null
     }})) {
       scheduleFlush();

--- a/lib/rsvp/map.js
+++ b/lib/rsvp/map.js
@@ -1,8 +1,7 @@
 import Promise from './promise';
 
 import {
-  isFunction,
-  isArray
+  isFunction
 } from './utils';
 
 /**
@@ -84,7 +83,7 @@ import {
   @static
 */
 export default function map(promises, mapFn, label) {
-  if (!isArray(promises)) {
+  if (!Array.isArray(promises)) {
     return Promise.reject(new TypeError("RSVP.map must be called with an array"), label);
   }
 

--- a/lib/rsvp/node.js
+++ b/lib/rsvp/node.js
@@ -4,7 +4,6 @@ import {
   resolve,
   reject
 } from './-internal';
-import { isArray } from './utils';
 
 function Result() {
   this.value = undefined;
@@ -229,7 +228,7 @@ export default function denodeify(nodeFunc, options) {
         resolve(promise, val);
       else if (options === true)
         resolve(promise, arrayResult(arguments));
-      else if (isArray(options))
+      else if (Array.isArray(options))
         resolve(promise, makeObject(arguments, options));
       else
         resolve(promise, val);

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -2,8 +2,7 @@ import { config } from './config';
 import instrument from './instrument';
 import then from './then';
 import {
-  isFunction,
-  now
+  isFunction
 } from './utils';
 
 import {
@@ -16,7 +15,7 @@ import race from './promise/race';
 import Resolve from './promise/resolve';
 import Reject from './promise/reject';
 
-const guidKey = 'rsvp_' + now() + '-';
+const guidKey = 'rsvp_' + Date.now() + '-';
 let counter = 0;
 
 function needsResolver() {

--- a/lib/rsvp/promise/all.js
+++ b/lib/rsvp/promise/all.js
@@ -1,5 +1,4 @@
 import Enumerator from '../enumerator';
-import { isArray } from '../utils';
 
 /**
   `RSVP.Promise.all` accepts an array of promises, and returns a new promise which
@@ -49,7 +48,7 @@ import { isArray } from '../utils';
   @static
 */
 export default function all(entries, label) {
-  if (!isArray(entries)) {
+  if (!Array.isArray(entries)) {
     return this.reject(new TypeError("Promise.all must be called with an array"), label);
   }
   return new Enumerator(this, entries, true /* abort on reject */, label).promise;

--- a/lib/rsvp/promise/race.js
+++ b/lib/rsvp/promise/race.js
@@ -1,8 +1,4 @@
 import {
-  isArray
-} from "../utils";
-
-import {
   noop,
   resolve,
   reject,
@@ -82,15 +78,17 @@ export default function race(entries, label) {
 
   let promise = new Constructor(noop, label);
 
-  if (!isArray(entries)) {
+  if (!Array.isArray(entries)) {
     reject(promise, new TypeError('Promise.race must be called with an array'));
     return promise;
   }
 
   for (let i = 0; promise._state === PENDING && i < entries.length; i++) {
-    subscribe(Constructor.resolve(entries[i]), undefined,
+    subscribe(
+      Constructor.resolve(entries[i]), undefined,
       value  => resolve(promise, value),
-      reason => reject(promise, reason));
+      reason => reject(promise, reason)
+    );
   }
 
   return promise;

--- a/lib/rsvp/utils.js
+++ b/lib/rsvp/utils.js
@@ -14,16 +14,3 @@ export function isObject(x) {
 export function isMaybeThenable(x) {
   return x !== null && typeof x === 'object';
 }
-
-let _isArray;
-if (Array.isArray) {
-  _isArray = Array.isArray;
-} else {
-  _isArray = x => Object.prototype.toString.call(x) === '[object Array]';
-}
-
-export const isArray = _isArray;
-
-// Date.now is not available in browsers < IE9
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now#Compatibility
-export const now = Date.now || (() => new Date().getTime());


### PR DESCRIPTION
maybe I am stepping ahead of myself here, but since most of ember core libs already dropped `es5` fallbacks, I think `rsvp` should also drop them going 4.0, free to close if you have other thoughts 