### PR TITLE
remove `onerror`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,6 @@ RSVP.on('error', function(reason, label) {
 **NOTE:** promises do allow for errors to be handled asynchronously, so
 this callback may result in false positives.
 
-**NOTE:** Usage of `RSVP.configure('onerror', yourCustomFunction);` is
-deprecated in favor of using `RSVP.on`.
-
-
 ## Finally
 
 `finally` will be invoked regardless of the promise's fate, just as native

--- a/lib/rsvp/config.js
+++ b/lib/rsvp/config.js
@@ -7,14 +7,6 @@ const config = {
 EventTarget['mixin'](config);
 
 function configure(name, value) {
-  if (name === 'onerror') {
-    // handle for legacy users that expect the actual
-    // error to be passed to their function added via
-    // `RSVP.configure('onerror', someFunctionHere);`
-    config['on']('error', value);
-    return;
-  }
-
   if (arguments.length === 2) {
     config[name] = value;
   } else {

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -150,7 +150,7 @@ class Promise {
   _onError(reason) {
     config.after(() => {
       if (this._onError) {
-        config['trigger']('error', reason, this._label);
+        config.trigger('error', reason, this._label);
       }
     });
   }

--- a/test/extension-test.js
+++ b/test/extension-test.js
@@ -1528,7 +1528,7 @@ describe("RSVP extensions", function() {
     it("When provided, any unhandled exceptions are sent to it (false positive case)", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error) {
+      RSVP.on('error', function(error) {
         assert.equal(error, thrownError, "The thrown error is passed in");
         done();
       });
@@ -1544,7 +1544,7 @@ describe("RSVP extensions", function() {
     it("onerror gets label if provided", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error, label) {
+      RSVP.on('error', function(error, label) {
         assert.equal(error, thrownError, "The thrown error is passed in");
         assert.equal(label, 'i am label', "the label for the given promise is also provided");
         done();
@@ -1561,7 +1561,7 @@ describe("RSVP extensions", function() {
     it("When provided, handled exceptions are not sent to it", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error) {
+      RSVP.on('error', function(error) {
         assert(false, "Should not get here");
       });
 
@@ -1576,7 +1576,7 @@ describe("RSVP extensions", function() {
     it("Enumerator: When provided, any unhandled exceptions are sent to it", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error) {
+      RSVP.on('error', function(error) {
         assert.equal(error, thrownError, "The thrown error is passed in");
         done();
       });
@@ -1594,7 +1594,7 @@ describe("RSVP extensions", function() {
     it("all When provided, handled exceptions are not sent to it", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error) {
+      RSVP.on('error', function(error) {
         assert(false, "Should not get here");
       });
 
@@ -1611,7 +1611,7 @@ describe("RSVP extensions", function() {
     it("assimilation: When provided, handled exceptions are not sent to it", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error) {
+      RSVP.on('error', function(error) {
         assert(false, "Should not get here");
       });
 
@@ -1626,7 +1626,7 @@ describe("RSVP extensions", function() {
     it("zalgo: When provided, unhandled exceptions are sent to it", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error) {
+      RSVP.on('error', function(error) {
         assert(true, "should also have emitted onerror");
         assert.equal(error, thrownError, "The handler should handle the error");
         done();
@@ -1643,7 +1643,7 @@ describe("RSVP extensions", function() {
     it("assimilation: When provided, unhandled exceptions are sent to it", function(done) {
       var thrownError = new Error();
 
-      RSVP.configure('onerror', function(error) {
+      RSVP.on('error', function(error) {
         assert(true, "Should get here once");
         done();
       });


### PR DESCRIPTION
I saw that note saying `RSVP.configure('onerror', ....  is deprecated` was up since 2013 so I guess its time to remove it :P  