### PR TITLE
fixed bug when truthy values would not filter correctly

### DIFF
--- a/lib/rsvp/filter.js
+++ b/lib/rsvp/filter.js
@@ -47,7 +47,7 @@ class FilterEnumerator extends Enumerator {
       }
     } else {
       this._remaining--;
-      if (value !== true) {
+      if (!value) {
         this._result[i] = EMPTY_OBJECT;
       }
     }

--- a/test/extension-test.js
+++ b/test/extension-test.js
@@ -2418,7 +2418,7 @@ describe("RSVP extensions", function() {
       }).catch(done);
     });
 
-    it("filters falsy values correctly", function(done){
+    it("filters falsy values correctly 1", function(done){
       var promises = [
         RSVP.resolve(false),
         RSVP.resolve(undefined),
@@ -2429,6 +2429,37 @@ describe("RSVP extensions", function() {
 
       RSVP.filter(promises, function(){ return true; }).then(function(results){
         assert.deepEqual([false, undefined, null, 0, ''], results);
+        done();
+      }).catch(done);
+    });
+
+    it("filters falsy values correctly 2", function(done){
+      var promises = [
+        RSVP.resolve(false),
+        RSVP.resolve(undefined),
+        RSVP.resolve(null),
+        RSVP.resolve(0),
+        RSVP.resolve('')
+      ];
+
+      RSVP.filter(promises, function(val){ return val; }).then(function(results){
+        assert.equal(results.length, 0);
+        done();
+      }).catch(done);
+    });
+
+    it("filters truthy values correctly", function(done){
+      var promises = [
+        RSVP.resolve(true),
+        RSVP.resolve(1),
+        RSVP.resolve(-10),
+        RSVP.resolve('a'),
+        RSVP.resolve({}),
+        RSVP.resolve([])
+      ];
+
+      RSVP.filter(promises, function(val){ return val; }).then(function(results){
+        assert.deepEqual(results, [true, 1, -10, 'a', {}, []]);
         done();
       }).catch(done);
     });


### PR DESCRIPTION
problem: it expected `true` to be result of filter function everything else was counted as false so it performed not like native `[].filter` which counts truthy values true not only `true`