### PR TITLE
[BUGFIX] throw exception when non array passed as a promise

### DIFF
--- a/lib/rsvp/filter.js
+++ b/lib/rsvp/filter.js
@@ -137,16 +137,15 @@ class FilterEnumerator extends Enumerator {
 */
 
 export default function filter(promises, filterFn, label) {
-  if (!Array.isArray(promises) && !(promises !== null && typeof promises === 'object' && promises.then !== undefined )) {
-    return Promise.reject(new TypeError("RSVP.filter must be called with an array or promise"), label);
-  }
-
   if (typeof filterFn !== 'function') {
     return Promise.reject(new TypeError("RSVP.filter expects function as a second argument"), label);
   }
 
   return Promise.resolve(promises, label)
     .then(function(promises) {
+      if (!Array.isArray(promises)) {
+        throw new TypeError("RSVP.filter must be called with an array");
+      }
       return new FilterEnumerator(Promise, promises, filterFn, label).promise;
     });
 }

--- a/test/extension-test.js
+++ b/test/extension-test.js
@@ -1362,11 +1362,15 @@ describe("RSVP extensions", function() {
 
   });
 
-  function assertRejection(promise) {
+  function assertRejection(promise, message) {
     return promise.then(function(){
       assert(false, 'expected rejection, but got fulfillment');
-    }, function(reason){
-      assert(reason instanceof Error);
+    }, function(e){
+      assert(e instanceof Error);
+      if (message) {
+        assert.equal(e.message, message);
+        console.log("e.message, message", message);
+      }
     });
   }
 
@@ -2410,11 +2414,24 @@ describe("RSVP extensions", function() {
     });
 
     it("throws an error if an array is not passed", function(){
-      assertRejection(RSVP.filter());
+      return assertRejection(
+        RSVP.filter(),
+        'RSVP.filter expects function as a second argument'
+      );
+    });
+
+    it("throws an error if is non array promise passed", function(){
+      return assertRejection(
+        RSVP.filter(Promise.resolve({}), function(){}),
+        'RSVP.filter must be called with an array'
+      );
     });
 
     it("throws an error if a filterFn is not passed", function(){
-      assertRejection(RSVP.filter([]));
+      return assertRejection(
+        RSVP.filter([]),
+        'RSVP.filter expects function as a second argument'
+      );
     });
 
     it("returns results that filterFn returns truthy values", function(done){


### PR DESCRIPTION
error would not be thrown previously if non array promise is passed to `RSVP.filter`  as `RSVP.filter(RSVP.resolve({}), function(){})`