### PR TITLE
Revert "drop `cast`"

### DIFF
--- a/lib/rsvp.js
+++ b/lib/rsvp.js
@@ -21,6 +21,7 @@ import asap from './rsvp/asap';
 // defaults
 config.async = asap;
 config.after = cb => setTimeout(cb, 0);
+const cast = resolve;
 
 const async = (callback, arg) => config.async(callback, arg);
 
@@ -47,6 +48,7 @@ if (typeof window !== 'undefined' && typeof window['__PROMISE_INSTRUMENTATION__'
 //   https://github.com/tildeio/rsvp.js/issues/434
 export default {
   asap,
+  cast,
   Promise,
   EventTarget,
   all,
@@ -69,6 +71,7 @@ export default {
 
 export {
   asap,
+  cast,
   Promise,
   EventTarget,
   all,

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -232,6 +232,7 @@ class Promise {
   }
 }
 
+Promise.cast = Resolve; // deprecated
 Promise.all = all;
 Promise.race = race;
 Promise.resolve = Resolve;


### PR DESCRIPTION
Reverts tildeio/rsvp.js#491

As reported in https://github.com/emberjs/ember.js/issues/16257, removing `RSVP.cast` was a breaking change (and was not previously deprecated at all). 