### PR TITLE
Mark all optional parameters using JSDoc syntax

### DIFF
--- a/lib/rsvp/all-settled.js
+++ b/lib/rsvp/all-settled.js
@@ -64,7 +64,7 @@ AllSettled.prototype._setResultAt = setSettledResult;
   @static
   @for rsvp
   @param {Array} entries
-  @param {String} label - optional string that describes the promise.
+  @param {String} [label] - optional string that describes the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled with an array of the settled
   states of the constituent promises.

--- a/lib/rsvp/all.js
+++ b/lib/rsvp/all.js
@@ -8,7 +8,7 @@ import Promise from "./promise";
   @static
   @for rsvp
   @param {Array} array Array of promises.
-  @param {String} label An optional label. This is useful
+  @param {String} [label] An optional label. This is useful
   for tooling.
 */
 export default function all(array, label) {

--- a/lib/rsvp/defer.js
+++ b/lib/rsvp/defer.js
@@ -29,7 +29,7 @@ import Promise from "./promise";
   @public
   @static
   @for rsvp
-  @param {String} label optional string for labeling the promise.
+  @param {String} [label] optional string for labeling the promise.
   Useful for tooling.
   @return {Object}
  */

--- a/lib/rsvp/events.js
+++ b/lib/rsvp/events.js
@@ -138,7 +138,7 @@ export default {
     @for rsvp
     @private
     @param {String} eventName event to stop listening to
-    @param {Function} callback optional argument. If given, only the function
+    @param {Function} [callback] optional argument. If given, only the function
     given will be removed from the event's callback queue. If no `callback`
     argument is given, all callbacks will be removed from the event's callback
     queue.
@@ -186,7 +186,7 @@ export default {
     @for rsvp
     @private
     @param {String} eventName name of the event to be triggered
-    @param {*} options optional value to be passed to any event handlers for
+    @param {*} [options] optional value to be passed to any event handlers for
     the given `eventName`
   */
   trigger(eventName, options, label) {

--- a/lib/rsvp/filter.js
+++ b/lib/rsvp/filter.js
@@ -123,7 +123,7 @@ class FilterEnumerator extends MapEnumerator {
   @param {Array} promises
   @param {Function} filterFn - function to be called on each resolved value to
   filter the final results.
-  @param {String} label optional string describing the promise. Useful for
+  @param {String} [label] optional string describing the promise. Useful for
   tooling.
   @return {Promise}
 */

--- a/lib/rsvp/hash-settled.js
+++ b/lib/rsvp/hash-settled.js
@@ -115,7 +115,7 @@ HashSettled.prototype._setResultAt = setSettledResult;
   @public
   @for rsvp
   @param {Object} object
-  @param {String} label optional string that describes the promise.
+  @param {String} [label] optional string that describes the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled when when all properties of `promises`
   have been settled.

--- a/lib/rsvp/hash.js
+++ b/lib/rsvp/hash.js
@@ -86,7 +86,7 @@ import PromiseHash from './promise-hash';
   @static
   @for rsvp
   @param {Object} object
-  @param {String} label optional string that describes the promise.
+  @param {String} [label] optional string that describes the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled when all properties of `promises`
   have been fulfilled, or rejected if any of them become rejected.

--- a/lib/rsvp/map.js
+++ b/lib/rsvp/map.js
@@ -115,7 +115,7 @@ export class MapEnumerator extends Enumerator {
   @for rsvp
   @param {Array} promises
   @param {Function} mapFn function to be called on each fulfilled promise.
-  @param {String} label optional string for labeling the promise.
+  @param {String} [label] optional string for labeling the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled with the result of calling
   `mapFn` on each fulfilled promise or value when they become fulfilled.

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -124,7 +124,7 @@ function needsNew() {
   @class Promise
   @public
   @param {function} resolver
-  @param {String} label optional string for labeling the promise.
+  @param {String} [label] optional string for labeling the promise.
   Useful for tooling.
   @constructor
 */
@@ -176,7 +176,7 @@ class Promise {
 
   @method catch
   @param {Function} onRejection
-  @param {String} label optional string for labeling the promise.
+  @param {String} [label] optional string for labeling the promise.
   Useful for tooling.
   @return {Promise}
 */
@@ -220,7 +220,7 @@ class Promise {
 
   @method finally
   @param {Function} callback
-  @param {String} label optional string for labeling the promise.
+  @param {String} [label] optional string for labeling the promise.
   Useful for tooling.
   @return {Promise}
 */
@@ -435,7 +435,7 @@ Promise.prototype._guidKey = guidKey;
   @method then
   @param {Function} onFulfillment
   @param {Function} onRejection
-  @param {String} label optional string for labeling the promise.
+  @param {String} [label] optional string for labeling the promise.
   Useful for tooling.
   @return {Promise}
 */

--- a/lib/rsvp/promise/all.js
+++ b/lib/rsvp/promise/all.js
@@ -45,7 +45,7 @@ import Enumerator from '../enumerator';
   @method all
   @for Promise
   @param {Array} entries array of promises
-  @param {String} label optional string for labeling the promise.
+  @param {String} [label] optional string for labeling the promise.
   Useful for tooling.
   @return {Promise} promise that is fulfilled when all `promises` have been
   fulfilled, or rejected if any of them become rejected.

--- a/lib/rsvp/promise/race.js
+++ b/lib/rsvp/promise/race.js
@@ -74,7 +74,7 @@ import {
   @for Promise
   @static
   @param {Array} entries array of promises to observe
-  @param {String} label optional string for describing the promise returned.
+  @param {String} [label] optional string for describing the promise returned.
   Useful for tooling.
   @return {Promise} a promise which settles in the same way as the first passed
   promise to settle.

--- a/lib/rsvp/promise/reject.js
+++ b/lib/rsvp/promise/reject.js
@@ -39,7 +39,7 @@ import {
   @for Promise
   @static
   @param {*} reason value that the returned promise will be rejected with.
-  @param {String} label optional string for identifying the returned promise.
+  @param {String} [label] optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise rejected with the given `reason`.
 */

--- a/lib/rsvp/promise/resolve.js
+++ b/lib/rsvp/promise/resolve.js
@@ -35,7 +35,7 @@ import {
   @for Promise
   @static
   @param {*} object value that the returned promise will be resolved with
-  @param {String} label optional string for identifying the returned promise.
+  @param {String} [label] optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise that will become fulfilled with the given
   `value`

--- a/lib/rsvp/race.js
+++ b/lib/rsvp/race.js
@@ -8,7 +8,7 @@ import Promise from './promise';
   @static
   @for rsvp
   @param {Array} array Array of promises.
-  @param {String} label An optional label. This is useful
+  @param {String} [label] An optional label. This is useful
   for tooling.
  */
 export default function race(array, label) {

--- a/lib/rsvp/reject.js
+++ b/lib/rsvp/reject.js
@@ -8,7 +8,7 @@ import Promise from './promise';
   @static
   @for rsvp
   @param {*} reason value that the returned promise will be rejected with.
-  @param {String} label optional string for identifying the returned promise.
+  @param {String} [label] optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise rejected with the given `reason`.
 */

--- a/lib/rsvp/resolve.js
+++ b/lib/rsvp/resolve.js
@@ -8,7 +8,7 @@ import Promise from './promise';
   @static
   @for rsvp
   @param {*} value value that the returned promise will be resolved with
-  @param {String} label optional string for identifying the returned promise.
+  @param {String} [label] optional string for identifying the returned promise.
   Useful for tooling.
   @return {Promise} a promise that will become fulfilled with the given
   `value`


### PR DESCRIPTION
I've marked all parameters describes as optional in JSDoc with [the JSDoc optional parameter syntax](http://usejsdoc.org/tags-param.html#optional-parameters-and-default-values) (surrounding their names in brackets). This helps hint IDEs like WebStorm that parameters are indeed optional so that they don't complain when you don't include an optional parameter in a function call.