### PR TITLE
Make example code import and use the right modules in the right way

### DIFF
--- a/lib/rsvp/hash-settled.js
+++ b/lib/rsvp/hash-settled.js
@@ -87,14 +87,14 @@ HashSettled.prototype._setResultAt = setSettledResult;
   Example:
 
   ```javascript
-  import Promise, { hashSettled, resolve } from 'rsvp';
+  import { hashSettled, resolve } from 'rsvp';
 
   function MyConstructor(){
     this.example = resolve('Example');
   }
 
   MyConstructor.prototype = {
-    protoProperty: Promise.resolve('Proto Property')
+    protoProperty: resolve('Proto Property')
   };
 
   let myObject = new MyConstructor();

--- a/lib/rsvp/promise.js
+++ b/lib/rsvp/promise.js
@@ -56,6 +56,8 @@ function needsNew() {
   ------------
 
   ```js
+  import { Promise } from 'rsvp';
+
   let promise = new Promise(function(resolve, reject) {
     // on success
     resolve(value);
@@ -78,6 +80,8 @@ function needsNew() {
   `XMLHttpRequest`s.
 
   ```js
+  import { Promise } from 'rsvp';
+
   function getJSON(url) {
     return new Promise(function(resolve, reject){
       let xhr = new XMLHttpRequest();

--- a/lib/rsvp/promise/all.js
+++ b/lib/rsvp/promise/all.js
@@ -1,7 +1,7 @@
 import Enumerator from '../enumerator';
 
 /**
-  `Promise.all` accepts an array of promises, and returns a new promise which
+  `all` accepts an array of promises, and returns a new promise which
   is fulfilled with an array of fulfillment values for the passed promises, or
   rejected with the reason of the first passed promise to be rejected. It casts all
   elements of the passed iterable to promises as it runs this algorithm.
@@ -9,14 +9,14 @@ import Enumerator from '../enumerator';
   Example:
 
   ```javascript
-  import Promise, { resolve } from 'rsvp';
+  import { all, resolve } from 'rsvp';
 
   let promise1 = resolve(1);
   let promise2 = resolve(2);
   let promise3 = resolve(3);
   let promises = [ promise1, promise2, promise3 ];
 
-  Promise.all(promises).then(function(array){
+  all(promises).then(function(array){
     // The array here would be [ 1, 2, 3 ];
   });
   ```
@@ -28,14 +28,14 @@ import Enumerator from '../enumerator';
   Example:
 
   ```javascript
-  import Promise, { resolve, reject } from 'rsvp';
+  import { all, resolve, reject } from 'rsvp';
 
   let promise1 = resolve(1);
   let promise2 = reject(new Error("2"));
   let promise3 = reject(new Error("3"));
   let promises = [ promise1, promise2, promise3 ];
 
-  Promise.all(promises).then(function(array){
+  all(promises).then(function(array){
     // Code here never runs because there are rejected promises!
   }, function(error) {
     // error.message === "2"

--- a/lib/rsvp/promise/race.js
+++ b/lib/rsvp/promise/race.js
@@ -7,13 +7,13 @@ import {
 } from '../-internal';
 
 /**
-  `Promise.race` returns a new promise which is settled in the same way as the
+  `race` returns a new promise which is settled in the same way as the
   first passed promise to settle.
 
   Example:
 
   ```javascript
-  import Promise from 'rsvp';
+  import { Promise, race } from 'rsvp';
 
   let promise1 = new Promise(function(resolve, reject){
     setTimeout(function(){
@@ -27,20 +27,20 @@ import {
     }, 100);
   });
 
-  Promise.race([promise1, promise2]).then(function(result){
+  race([promise1, promise2]).then(function(result){
     // result === 'promise 2' because it was resolved before promise1
     // was resolved.
   });
   ```
 
-  `Promise.race` is deterministic in that only the state of the first
+  `race` is deterministic in that only the state of the first
   settled promise matters. For example, even if other promises given to the
   `promises` array argument are resolved, but the first settled promise has
   become rejected before the other promises became fulfilled, the returned
   promise will become rejected:
 
   ```javascript
-  import Promise from 'rsvp';
+  import { Promise, race } from 'rsvp';
 
   let promise1 = new Promise(function(resolve, reject){
     setTimeout(function(){
@@ -54,7 +54,7 @@ import {
     }, 100);
   });
 
-  Promise.race([promise1, promise2]).then(function(result){
+  race([promise1, promise2]).then(function(result){
     // Code here never runs
   }, function(reason){
     // reason.message === 'promise 2' because promise 2 became rejected before
@@ -65,9 +65,9 @@ import {
   An example real-world use case is implementing timeouts:
 
   ```javascript
-  import Promise from 'rsvp';
+  import { Promise, race } from 'rsvp';
 
-  Promise.race([ajax('foo.json'), timeout(5000)])
+  race([ajax('foo.json'), timeout(5000)])
   ```
 
   @method race

--- a/lib/rsvp/promise/reject.js
+++ b/lib/rsvp/promise/reject.js
@@ -4,11 +4,11 @@ import {
 } from '../-internal';
 
 /**
-  `Promise.reject` returns a promise rejected with the passed `reason`.
+  `reject` returns a promise rejected with the passed `reason`.
   It is shorthand for the following:
 
   ```javascript
-  import Promise from 'rsvp';
+  import { Promise } from 'rsvp';
 
   let promise = new Promise(function(resolve, reject){
     reject(new Error('WHOOPS'));
@@ -24,9 +24,9 @@ import {
   Instead of writing the above, your code now simply becomes the following:
 
   ```javascript
-  import Promise from 'rsvp';
+  import { reject } from 'rsvp';
 
-  let promise = Promise.reject(new Error('WHOOPS'));
+  let promise = reject(new Error('WHOOPS'));
 
   promise.then(function(value){
     // Code here doesn't run because the promise is rejected!

--- a/lib/rsvp/promise/resolve.js
+++ b/lib/rsvp/promise/resolve.js
@@ -4,11 +4,11 @@ import {
 } from '../-internal';
 
 /**
-  `Promise.resolve` returns a promise that will become resolved with the
+  `resolve` returns a promise that will become resolved with the
   passed `value`. It is shorthand for the following:
 
   ```javascript
-  import Promise from 'rsvp';
+  import { Promise } from 'rsvp';
 
   let promise = new Promise(function(resolve, reject){
     resolve(1);
@@ -22,9 +22,9 @@ import {
   Instead of writing the above, your code now simply becomes the following:
 
   ```javascript
-  import Promise from 'rsvp';
+  import { resolve } from 'rsvp';
 
-  let promise = RSVP.Promise.resolve(1);
+  let promise = resolve(1);
 
   promise.then(function(value){
     // value === 1

--- a/lib/rsvp/rethrow.js
+++ b/lib/rsvp/rethrow.js
@@ -11,7 +11,7 @@
   error again so the error can be handled by the promise per the spec.
 
   ```javascript
-  import { rethrow } from 'rsvp';
+  import { Promise, rethrow } from 'rsvp';
 
   function throws(){
     throw new Error('Whoops!');


### PR DESCRIPTION
The former example where not technically wrong but pretty misleading,
since they suggested `Promise` (the one that can be used in
`new Promise`) is the default export of the `rsvp` package when it isn't.
Ideally when using the default import it should be called `RSVP` rather
then `Promise` but in fact neither of the code example require to use
that default export at all so I removed using that in the examples
entirely.