### PR TITLE
Make recommendation against `defer` less strict

### DIFF
--- a/lib/rsvp/defer.js
+++ b/lib/rsvp/defer.js
@@ -3,7 +3,9 @@ import Promise from "./promise";
 /**
   `defer` returns an object similar to jQuery's `$.Deferred`.
   `defer` should be used when porting over code reliant on `$.Deferred`'s
-  interface. New code should use the `Promise` constructor instead.
+  interface. New code should usually use the `Promise` constructor instead,
+  but `defer` may still be useful in some contexts, especially when writing
+  tests.
 
   The object returned from `defer` is a plain object with three properties:
 


### PR DESCRIPTION
There are plenty of cases, especially when writing tests, where it makes more sense to use `defer` than to do something like
```
let resolvePromise;
let promise = new Promise(resolve => {
  resolvePromise = resolve;
});
stubReturn(promise);
// test loading state
resolvePromise(...);
// test resolved state
```