### PR TITLE
fix pkg module reference to original entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "license": "MIT",
   "main": "dist/rsvp.js",
-  "module": "dist/rsvp.es.js",
+  "module": "lib/rsvp.js",
   "namespace": "RSVP",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@stefanpenner I had a very weird silent build bug when I tried to run `router_js` with my emberx experiment: https://github.com/izelnakri/emberx/tree/rsvp-fail . The tests were failing with both `esbuild` and `tsc` outputs, after some in-depth investigation I found that this reference is causing the problem. I fixed it in this commit, and tests started passing(you can ignore the Dockerfile change): https://github.com/izelnakri/emberx/commit/5312bf2165fca94171ef471a45cbbdca7041f8cc

## What is happening?
This library has not been published for 2 years, mainly I suppose there was no need for it. It has 0 dependencies, however the package itself tries to do some runtime imports and its runtime changes based on that: https://github.com/tildeio/rsvp.js/blob/master/lib/rsvp/asap.js#L90

When I change the "module" entry `scheduleFlush` get assigned to different functions between `dist/rsvp.es.js`(original) and `lib/rsvp.js`(current fix). Original entry results in runtime error on my specific tests in browser that are built on top of `router_js`.

This makes `router_js` which depends on `rsvp` not runnable correctly on node.js and browser environments until we apply the change in this PR.

## Steps to reproduce 

- Clone emberx repo: https://github.com/izelnakri/emberx

- Change branch to `rsvp-fail`: https://github.com/izelnakri/emberx/tree/rsvp-fail

- Install dependencies and run tests: `$ npm install && npm run test` . Tests should fail with runtime error, smt like `_state of undefined`

- Apply this commit: https://github.com/izelnakri/emberx/commit/5312bf2165fca94171ef471a45cbbdca7041f8cc

- Run the tests again: `$ npm run test` . Tests should pass now.


Although this is a temporary solution, I think we should merge it because the library itself is written in es modules, so module reference shouldn't need a build step, including for ember-cli environments. This removes the extra layer of indirection between the library code and its runtime as we simplfy the library build process for modern bundlers. Transpiling the code with both `esbuild` and `tsc` both gives the same runtime error.